### PR TITLE
feat: add InfoLine and Tile components for improved UI structure

### DIFF
--- a/packages/idae-machine/.github/copilot-instructions.md
+++ b/packages/idae-machine/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+<!-- mermaid-ai-skills:start -->
+## Mermaid Diagrams
+
+When the user asks to create, edit, or visualize a diagram, follow the
+instructions in `.github/instructions/mermaid.instructions.md`.
+<!-- mermaid-ai-skills:end -->

--- a/packages/idae-machine/.github/instructions/mermaid.instructions.md
+++ b/packages/idae-machine/.github/instructions/mermaid.instructions.md
@@ -1,0 +1,85 @@
+---
+applyTo: "**"
+---
+# Mermaid AI Skills
+
+When the user asks to create, edit, or visualize any diagram, use the Mermaid
+VS Code extension tools and commands described below.
+
+## Workflow
+
+1. Determine the diagram type and generate Mermaid syntax.
+2. Write the diagram to a `.mmd` file in the project.
+3. Validate syntax: correct first-line keyword, arrow types, balanced brackets.
+4. Preview via the Mermaid extension — open the `.mmd` file (auto-preview) or run
+   **MermaidChart: Preview Diagram** (`mermaidChart.preview`).
+
+## LM Tools — call these for every diagram interaction
+
+- `mermaid-diagram-validator` — validate Mermaid syntax before presenting any diagram
+- `mermaid-diagram-preview` — render a live preview inside VS Code after generating
+- `get-syntax-docs-mermaid` — fetch correct syntax docs for any diagram type
+
+## VS Code Commands
+
+Invoke via Command Palette or the VS Code command API (GitHub Copilot in VS Code only).
+Do not invent command IDs. Prefer writing/editing `.mmd` files when a command is not needed.
+
+### Diagram editing & preview
+- **Preview** (`mermaidChart.preview`) — preview the active Mermaid editor (`.mmd` / `.mermaid` must be open).
+- **Create Diagram** (`mermaidChart.createMermaidFile`) — creates a demo flowchart and opens preview side by side.
+- **Repair Diagram** (`mermaidChart.repairDiagram`) — Mermaid AI repair for the active diagram; uses Mermaid AI credits — tell the user before running.
+- **Improve Diagram** (`mermaidChart.improveDiagram`) — uses Copilot / LM API; suggests layout + styling variants for the active diagram.
+
+### Generate diagrams (GitHub Copilot required)
+- **Generate Diagram from Code** (`mermaidChart.generateDiagramFromCode`)
+- **Generate Cloud Diagram** (`mermaidChart.generateCloudDiagram`)
+- **Generate ER Diagram** (`mermaidChart.generateERDiagram`)
+- **Generate Docker Diagram** (`mermaidChart.generateDockerDiagram`)
+- **Open AI Chat** (`mermaidChart.openCopilotChat`)
+
+### Mermaid Chart cloud
+- **Login** (`mermaidChart.login`) / **Logout** (`mermaidChart.logout`)
+- **Connect Diagram** (`mermaidChart.connectDiagramToMermaidChart`) — link a local diagram to Mermaid Chart.
+- **Sync Diagram** (`mermaidChart.syncDiagramWithMermaid`) — only for diagrams already connected (frontmatter has `id:`). Example:
+  ```yaml
+  ---
+  id: cbd9e9ba-a2cb-47c5-a98e-8c28a753428d
+  ---
+  ```
+
+### Review Mermaid Sync
+For diagrams updated by the Mermaid Chart GitHub Sync app (or pre-commit regenerate):
+- **Review Mermaid Sync** (`mermaidChart.reviewAppCommits`) — start / open the review flow.
+- **Regenerate with Mermaid AI** (`mermaidChart.regenerateDiagramWithMermaidAI`) — regenerate from source references.
+Do not manually rewrite diagrams managed by this workflow. Accept/reject/diff UI actions stay in the extension UI.
+
+### Install / update this pack
+- **MermaidChart: Install AI Skills…** (`mermaidChart.installAiSkills`)
+
+## @mermaid-chart slash commands
+
+| Command | Purpose |
+|---|---|
+| `/generate_diagram_from_code` | General diagram from any source file |
+| `/generate_execution_sequence` | Sequence diagram from code flow |
+| `/generate_er_diagram` | ER diagram from schema / models |
+| `/generate_cloud_architecture_diagram` | Cloud / CI-CD architecture |
+| `/generate_docker_diagram` | Architecture from Dockerfiles |
+| `/generate_c4_topdown_architecture` | C4 top-down architecture |
+| `/analyze_code_ownership` | Code ownership diagram |
+| `/generate_dependency_diagram` | Dependency / security visualisation |
+
+## Rules
+
+1. Always call `mermaid-diagram-validator` before showing any diagram.
+2. Always call `mermaid-diagram-preview` after generating a diagram.
+3. Use `get-syntax-docs-mermaid` before generating an unfamiliar diagram type.
+4. Prefer `@mermaid-chart` slash commands for complex generation.
+5. Write diagrams to `.mmd` files; never return unvalidated Mermaid syntax.
+6. Warn the user before Repair (Mermaid AI credits).
+7. Cooperate with the Sync workflow — do not manually regenerate managed diagrams.
+
+## Docs
+
+More commands and features: https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart

--- a/packages/idae-machine/src/lib/data-ui/controls/AlphabetFilter.svelte
+++ b/packages/idae-machine/src/lib/data-ui/controls/AlphabetFilter.svelte
@@ -1,0 +1,114 @@
+<!--
+AlphabetFilter.svelte
+First-letter index for a collection's presentation field. Bindable `where` emits
+{ [field]: { startsWith: letter } } or undefined ("Tous").
+
+Operator keys are BARE, not $-prefixed: qoolie's matchOperators switches on 'eq' /
+'startsWith' / 'contains' and has no default branch, so a '$startsWith' key is skipped
+and the clause matches every record instead of filtering. (The $-prefixed spelling in
+node_modules/@medyll/qoolie/dist/lib/operators.d.ts is a stale published artifact — the
+linked workspace source in packages/qoolie is authoritative.)
+
+Letters are derived from the data rather than hardcoded A-Z: startsWith is also
+case-SENSITIVE, so a fixed uppercase alphabet silently matches nothing on
+lowercase-stored values. Offering only the initials that actually occur — in their
+stored case — makes every button a guaranteed hit and mirrors the legacy screen, which
+built its index from a distinct() over the column.
+
+@prop {string} collection
+@prop {string} [field] - defaults to the first token of template.presentation
+@prop {Where|undefined} [where] - $bindable
+@prop {string|undefined} [letter] - $bindable selected letter (as stored)
+-->
+<script module lang="ts">
+	import type { Where } from '$lib/types/index.js';
+
+	export interface AlphabetFilterProps {
+		collection: string;
+		field?: string;
+		where?: Where | undefined;
+		letter?: string | undefined;
+	}
+</script>
+
+<script lang="ts">
+	import { machine } from '$lib/main/machine.js';
+
+	let {
+		collection,
+		field,
+		where = $bindable(undefined),
+		letter = $bindable(undefined)
+	}: AlphabetFilterProps = $props();
+
+	// Setup-time subscription — collection is fixed per instance (CLAUDE.md invariant 10).
+	const src = machine.store<Record<string, unknown>>(collection);
+
+	const effectiveField = $derived.by(() => {
+		if (field) return field;
+		const scheme = machine.logic.collection(collection);
+		const presentation = scheme?.template?.presentation as string | undefined;
+		return presentation?.split(/\s+/).filter(Boolean)[0];
+	});
+
+	// Distinct stored initials. Mixed-case data yields one entry per stored case; each
+	// still matches, which is preferable to a merged entry that would drop records.
+	const letters = $derived.by(() => {
+		const key = effectiveField;
+		if (!key) return [];
+		const seen = new Set<string>();
+		for (const record of src.records as Record<string, unknown>[]) {
+			const raw = record[key];
+			if (typeof raw !== 'string' || raw.length === 0) continue;
+			seen.add(raw[0]);
+		}
+		return [...seen].sort((a, b) => a.localeCompare(b));
+	});
+
+	function select(next: string | undefined): void {
+		letter = next;
+		where = next && effectiveField ? { [effectiveField]: { startsWith: next } } : undefined;
+	}
+</script>
+
+<div class="alphabet-filter" role="group" aria-label="Filtrer par lettre">
+	<button type="button" class="alphabet-filter-item" aria-pressed={letter == null} onclick={() => select(undefined)}>
+		Tous
+	</button>
+	{#each letters as l (l)}
+		<button type="button" class="alphabet-filter-item" aria-pressed={letter === l} onclick={() => select(l)}>
+			{l.toLocaleUpperCase()}
+		</button>
+	{/each}
+</div>
+
+<style>
+	@layer components {
+		.alphabet-filter {
+			display: flex;
+			flex-wrap: wrap;
+			gap: var(--gutter-xs);
+		}
+		.alphabet-filter-item {
+			all: unset;
+			box-sizing: border-box;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			min-width: var(--control-height);
+			min-height: var(--control-height);
+			padding: 0 var(--pad-xs);
+			border-radius: var(--radius-xs);
+			font-size: var(--text-xs);
+			cursor: pointer;
+			color: var(--color-text);
+		}
+		.alphabet-filter-item:hover {
+			background: var(--color-surface-hover);
+		}
+		.alphabet-filter-item[aria-pressed='true'] {
+			background: var(--color-primary);
+			color: var(--default-color-surface-light);
+		}
+	}
+</style>

--- a/packages/idae-machine/src/lib/data-ui/controls/DataFind.svelte
+++ b/packages/idae-machine/src/lib/data-ui/controls/DataFind.svelte
@@ -89,7 +89,12 @@ Debounced schema-aware search. Advanced mode exposes the field and match operato
 					} else if (mode === 'exact' && fieldType === 'boolean') {
 						queryValue = kw === 'true';
 					}
-					where = { [field]: { [mode === 'exact' ? '$eq' : '$contains']: queryValue } };
+					// Operator keys are BARE, never $-prefixed: qoolie's matchOperators
+					// switches on 'eq'/'contains'/... with no default branch, so a '$eq'
+					// key is skipped and the clause silently matches every record.
+					// (The $-spelling in node_modules/@medyll/qoolie/dist/lib/operators.d.ts
+					// is a stale published artifact — packages/qoolie/src is authoritative.)
+					where = { [field]: { [mode === 'exact' ? 'eq' : 'contains']: queryValue } };
 				}
 			});
 		}, debounceMs);

--- a/packages/idae-machine/src/lib/data-ui/controls/FkFilter.svelte
+++ b/packages/idae-machine/src/lib/data-ui/controls/FkFilter.svelte
@@ -1,0 +1,94 @@
+<!--
+FkFilter.svelte
+Single-FK select filter. Options are the target collection's records, labeled via
+its presentation template. Emits a where fragment matching whichever convention the
+source collection actually stores the relation in: the flat scalar field resolved via
+scheme.findFkField (e.g. `category: "compact"` — the common case in real/seed data),
+falling back to the nested join snapshot dot path (`fks.<fkName>.code`) when no flat
+field is registered. Same nested-then-flat priority as dataRelationUtils.resolveForwardRelations.
+
+@prop {string} collection - source collection (owns the FK)
+@prop {string} fkName - key in scheme.fks
+@prop {Where|undefined} [where] - $bindable
+@prop {string|undefined} [value] - $bindable selected target code
+@prop {string} [label] - defaults to fkName
+-->
+<script module lang="ts">
+	import type { Where } from '$lib/types/index.js';
+
+	export interface FkFilterProps {
+		collection: string;
+		fkName: string;
+		where?: Where | undefined;
+		value?: string | undefined;
+		label?: string;
+	}
+</script>
+
+<script lang="ts">
+	import { machine } from '$lib/main/machine.js';
+
+	let {
+		collection,
+		fkName,
+		where = $bindable(undefined),
+		value = $bindable(undefined),
+		label
+	}: FkFilterProps = $props();
+
+	const scheme = machine.logic.collection(collection);
+	const targetCollection = scheme?.fks?.[fkName]?.code;
+	// findFkField matches on the TARGET collection, so a source declaring two FKs to the
+	// same target resolves both to the first one — filtering by either then narrows the
+	// same field. No current model does this; revisit here if one starts to.
+	const fieldInfo = targetCollection ? (scheme?.findFkField(targetCollection) ?? null) : null;
+	const targetIndexKey = fieldInfo?.targetIndex ?? 'code';
+
+	// Setup-time subscription — fkName/targetCollection are fixed per instance.
+	const targetStore = targetCollection ? machine.store<Record<string, unknown>>(targetCollection) : null;
+	const targetScheme = targetCollection ? machine.logic.collection(targetCollection) : null;
+
+	const options = $derived.by(() => {
+		if (!targetStore || !targetScheme) return [];
+		return (targetStore.records as Record<string, unknown>[])
+			.map((record) => ({
+				key: String(record[targetIndexKey] ?? record.code ?? record.id ?? ''),
+				label: targetScheme.collectionValues.presentation(record) || String(record.code ?? record.id ?? '')
+			}))
+			.sort((a, b) => a.label.localeCompare(b.label));
+	});
+
+	function select(next: string): void {
+		value = next || undefined;
+		if (!value) {
+			where = undefined;
+		} else {
+			where = fieldInfo ? { [fieldInfo.fieldName]: value } : { [`fks.${fkName}.code`]: value };
+		}
+	}
+</script>
+
+<label class="fk-filter">
+	<span class="fk-filter-label">{label ?? fkName}</span>
+	<select class="form-select" value={value ?? ''} onchange={(e) => select(e.currentTarget.value)}>
+		<option value="">Tous</option>
+		{#each options as option (option.key)}
+			<option value={option.key}>{option.label}</option>
+		{/each}
+	</select>
+</label>
+
+<style>
+	@layer components {
+		.fk-filter {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-xs);
+		}
+		.fk-filter-label {
+			font-size: var(--text-xs);
+			color: var(--color-text-muted);
+			text-transform: capitalize;
+		}
+	}
+</style>

--- a/packages/idae-machine/src/lib/data-ui/data/DataCount.svelte
+++ b/packages/idae-machine/src/lib/data-ui/data/DataCount.svelte
@@ -1,0 +1,67 @@
+<!--
+DataCount.svelte
+Reactive record count for a collection — `machine.store(collection, where).records.length`,
+optionally narrowed by a client-side predicate (for aggregates qoolie's Where can't express:
+orphans, status exclusion, distinct…).
+
+`where` is captured once at setup and passed straight to machine.store — per CLAUDE.md
+invariant 10, machine.store() registers a subscription at call time and must not be
+re-invoked reactively. A reactive query is expressed via `filter` instead, evaluated
+inside the `count` $derived over the already-subscribed `records`.
+
+@prop {string} collection
+@prop {Where<T>} [where] - static qoolie where, applied at the store subscription
+@prop {(record: T) => boolean} [filter] - reactive client-side predicate, applied on top of `where`
+@prop {string} [label]
+@snippet children({ count, records }) - custom rendering; default = label + count
+-->
+<script module lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { Where } from '$lib/types/index.js';
+
+	export interface DataCountProps<T extends Record<string, unknown> = Record<string, unknown>> {
+		collection: string;
+		where?: Where<T>;
+		filter?: (record: T) => boolean;
+		label?: string;
+		children?: Snippet<[{ count: number; records: T[] }]>;
+	}
+</script>
+
+<script lang="ts" generics="T extends Record<string, unknown>">
+	import { machine } from '$lib/main/machine.js';
+
+	let { collection, where, filter, label, children }: DataCountProps<T> = $props();
+
+	// Setup-time subscription only — see file header.
+	const src = machine.store<T>(collection, where);
+
+	const records = $derived(filter ? (src.records as T[]).filter(filter) : (src.records as T[]));
+	const count = $derived(records.length);
+</script>
+
+{#if children}
+	{@render children({ count, records })}
+{:else}
+	<data-count-fragment>
+		{#if label}<span class="data-count-label">{label}</span>{/if}
+		<span class="data-count-value">{count}</span>
+	</data-count-fragment>
+{/if}
+
+<style>
+	@layer components {
+		data-count-fragment {
+			display: inline-flex;
+			align-items: baseline;
+			gap: var(--gutter-xs);
+		}
+		.data-count-label {
+			color: var(--color-text-muted);
+			font-size: var(--text-sm);
+		}
+		.data-count-value {
+			font-weight: var(--font-semibold);
+		}
+	}
+</style>

--- a/packages/idae-machine/src/lib/data-ui/data/DataCount.svelte.test.ts
+++ b/packages/idae-machine/src/lib/data-ui/data/DataCount.svelte.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { flushSync, tick } from 'svelte';
+import { cleanup, render } from '@testing-library/svelte';
+import type { MachineModel } from '$lib/types/index.js';
+import { machine } from '$lib/main/machine.js';
+import DataCount from './DataCount.svelte';
+
+// DataCount reads the `machine` singleton, so tests cannot swap in an isolated Machine
+// instance the way the machineDb suites do. Records also survive machine.destroy() +
+// a fresh IDBFactory (verified: a re-booted singleton still reads the previous test's
+// rows), so isolation comes from giving each test its own collection instead.
+const COLLECTIONS = ['w_total', 'w_where', 'w_filter', 'w_reactive', 'w_empty'] as const;
+
+const model: MachineModel = Object.fromEntries(
+	COLLECTIONS.map((name) => [
+		name,
+		{
+			keyPath: '++id',
+			base: 'machine_base',
+			fields: {
+				id:     { type: 'id', readonly: true },
+				code:   { type: 'text', required: true },
+				status: { type: 'text' }
+			},
+			fkRelations: {},
+			template: { presentation: 'code' }
+		}
+	])
+) as MachineModel;
+
+async function settle(): Promise<void> {
+	flushSync();
+	await tick();
+	flushSync();
+	await tick();
+}
+
+function countText(container: HTMLElement): string | undefined {
+	return container.querySelector('.data-count-value')?.textContent ?? undefined;
+}
+
+describe('DataCount', () => {
+	beforeEach(async () => {
+		machine.destroy();
+		machine.init({ dbName: 'datacount', version: 1, core: model, business: {}, sync: false });
+		await machine.boot();
+	});
+
+	afterEach(() => {
+		// Unmount before destroying: a live DataCount keeps its machine.store subscription.
+		cleanup();
+		machine.destroy();
+	});
+
+	it('renders the collection total with its label', async () => {
+		await machine.collection('w_total').create({ code: 'a', status: 'open' });
+		await machine.collection('w_total').create({ code: 'b', status: 'done' });
+
+		const { container } = render(DataCount, { collection: 'w_total', label: 'Total' });
+		await settle();
+
+		expect(container.querySelector('.data-count-label')?.textContent).toBe('Total');
+		expect(countText(container)).toBe('2');
+	});
+
+	it('narrows the count with a static where', async () => {
+		await machine.collection('w_where').create({ code: 'a', status: 'open' });
+		await machine.collection('w_where').create({ code: 'b', status: 'done' });
+		await machine.collection('w_where').create({ code: 'c', status: 'open' });
+
+		const { container } = render(DataCount, {
+			collection: 'w_where',
+			where: { status: 'open' }
+		});
+		await settle();
+
+		expect(countText(container)).toBe('2');
+	});
+
+	it('applies the client-side filter predicate on top of the store records', async () => {
+		await machine.collection('w_filter').create({ code: 'keep', status: 'open' });
+		await machine.collection('w_filter').create({ code: 'drop', status: 'open' });
+
+		const { container } = render(DataCount, {
+			collection: 'w_filter',
+			filter: (record: Record<string, unknown>) => record.code === 'keep'
+		});
+		await settle();
+
+		expect(countText(container)).toBe('1');
+	});
+
+	it('reacts to records created after mount', async () => {
+		await machine.collection('w_reactive').create({ code: 'a' });
+
+		const { container } = render(DataCount, { collection: 'w_reactive' });
+		await settle();
+		expect(countText(container)).toBe('1');
+
+		await machine.collection('w_reactive').create({ code: 'b' });
+		await settle();
+
+		expect(countText(container)).toBe('2');
+	});
+
+	it('renders zero for an empty collection', async () => {
+		const { container } = render(DataCount, { collection: 'w_empty' });
+		await settle();
+
+		expect(countText(container)).toBe('0');
+	});
+});

--- a/packages/idae-machine/src/lib/data-ui/fragments/InfoLine.svelte
+++ b/packages/idae-machine/src/lib/data-ui/fragments/InfoLine.svelte
@@ -1,0 +1,123 @@
+<!--
+InfoLine.svelte
+Label/value line, optional secondary hint and progress bar. Used inside Tile
+panels (classification breakdown, period counters, FK card metadata).
+
+A clickable line renders as a real <button>, a static one as <info-line-fragment>;
+both carry .info-line-fragment so one rule styles the grid.
+
+@prop {string} label
+@prop {string|number} [value]
+@prop {string} [hint] - secondary text, e.g. "3 sur 12"
+@prop {number} [progress] - 0..1, renders a progress bar under the line
+@prop {Snippet} [children] - custom value area, overrides `value`
+@prop {() => void} [onclick]
+-->
+<script module lang="ts">
+	import type { Snippet } from 'svelte';
+
+	export interface InfoLineProps {
+		label: string;
+		value?: string | number;
+		hint?: string;
+		progress?: number;
+		children?: Snippet;
+		onclick?: () => void;
+	}
+</script>
+
+<script lang="ts">
+	let { label, value, hint, progress, children, onclick }: InfoLineProps = $props();
+
+	const clampedProgress = $derived(
+		progress == null ? undefined : Math.min(1, Math.max(0, progress))
+	);
+</script>
+
+{#snippet inner()}
+	<span class="info-line-label">{label}</span>
+	<span class="info-line-value">
+		{#if children}
+			{@render children()}
+		{:else}
+			{value ?? '—'}
+		{/if}
+		{#if hint}<span class="info-line-hint">{hint}</span>{/if}
+	</span>
+	{#if clampedProgress != null}
+		<span class="info-line-progress" style={`--progress: ${clampedProgress};`}>
+			<span class="info-line-progress-bar"></span>
+		</span>
+	{/if}
+{/snippet}
+
+{#if onclick}
+	<button type="button" class="info-line-fragment info-line-fragment--clickable" {onclick}>
+		{@render inner()}
+	</button>
+{:else}
+	<info-line-fragment class="info-line-fragment">
+		{@render inner()}
+	</info-line-fragment>
+{/if}
+
+<style>
+	@layer components {
+		.info-line-fragment {
+			display: grid;
+			grid-template-columns: 1fr auto;
+			align-items: baseline;
+			gap: var(--gutter-xs) var(--gutter-sm);
+			padding: var(--pad-xs) 0;
+			color: var(--color-text);
+			font: inherit;
+			text-align: start;
+		}
+		/* Button normalisation only — grid/spacing come from .info-line-fragment above. */
+		.info-line-fragment--clickable {
+			appearance: none;
+			border: none;
+			background: transparent;
+			inline-size: 100%;
+			cursor: pointer;
+		}
+		.info-line-fragment--clickable:hover {
+			color: var(--color-primary);
+		}
+		.info-line-label {
+			text-transform: capitalize;
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+		.info-line-value {
+			display: inline-flex;
+			align-items: baseline;
+			gap: var(--gutter-xs);
+			font-weight: var(--font-semibold);
+			white-space: nowrap;
+		}
+		.info-line-hint {
+			font-weight: var(--font-normal);
+			font-size: var(--text-xs);
+			color: var(--color-text-muted);
+		}
+		.info-line-progress {
+			grid-column: 1 / -1;
+			display: block;
+			inline-size: 100%;
+			block-size: calc(var(--gutter-xs) / 2);
+			background: var(--color-surface-sunken);
+			border-radius: var(--radius-full);
+			overflow: hidden;
+		}
+		.info-line-progress-bar {
+			display: block;
+			block-size: 100%;
+			inline-size: calc(var(--progress) * 100%);
+			background: var(--color-primary);
+			border-radius: var(--radius-full);
+		}
+	}
+</style>

--- a/packages/idae-machine/src/lib/data-ui/fragments/Tile.svelte
+++ b/packages/idae-machine/src/lib/data-ui/fragments/Tile.svelte
@@ -1,0 +1,126 @@
+<!--
+Tile.svelte
+Generic card/section shell — title + icon header, body, optional footer, optional
+whole-tile click. Shared by Space (classification/FK/period panels) and Today
+(quick-create/my-lists/echeancier sections).
+
+A clickable tile renders as a real <button> (native semantics, no role/tabindex
+patching); a static one renders as <tile-fragment>. Both carry the .tile-fragment
+class so a single CSS rule styles them — the --clickable modifier only adds button
+normalisation and hover.
+
+@prop {string} [title]
+@prop {string} [icon] - Iconify icon name; bare names are prefixed with "ph:"
+@prop {string} [accentColor] - CSS color value applied as --tile-accent
+@prop {Snippet} [header] - overrides the default title/icon line
+@prop {Snippet} [footer]
+@prop {Snippet} children
+@prop {() => void} [onclick] - whole-tile click (renders as a button)
+@prop {string} [class]
+-->
+<script module lang="ts">
+	import type { Snippet } from 'svelte';
+
+	export interface TileProps {
+		title?: string;
+		icon?: string;
+		accentColor?: string;
+		header?: Snippet;
+		footer?: Snippet;
+		children: Snippet;
+		onclick?: () => void;
+		class?: string;
+	}
+</script>
+
+<script lang="ts">
+	import Icon from '@iconify/svelte';
+
+	let { title, icon, accentColor, header, footer, children, onclick, class: className }: TileProps =
+		$props();
+
+	function normalizeIcon(value: string): string {
+		const trimmed = value.trim();
+		return trimmed.includes(':') ? trimmed : `ph:${trimmed}`;
+	}
+
+	const style = $derived(accentColor ? `--tile-accent: ${accentColor};` : undefined);
+</script>
+
+{#snippet inner()}
+	{#if header}
+		<tile-header>{@render header()}</tile-header>
+	{:else if title || icon}
+		<tile-header>
+			{#if icon}<span class="tile-icon"><Icon icon={normalizeIcon(icon)} /></span>{/if}
+			{#if title}<span class="tile-title">{title}</span>{/if}
+		</tile-header>
+	{/if}
+	<tile-body>
+		{@render children()}
+	</tile-body>
+	{#if footer}
+		<tile-footer>{@render footer()}</tile-footer>
+	{/if}
+{/snippet}
+
+{#if onclick}
+	<button type="button" class="tile-fragment tile-fragment--clickable {className ?? ''}" {style} {onclick}>
+		{@render inner()}
+	</button>
+{:else}
+	<tile-fragment class="tile-fragment {className ?? ''}" {style}>
+		{@render inner()}
+	</tile-fragment>
+{/if}
+
+<style>
+	@layer components {
+		.tile-fragment {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-xs);
+			padding: var(--pad-sm);
+			border: var(--border-width) solid var(--color-border);
+			border-radius: var(--radius-xs);
+			background: var(--color-surface-alt);
+			border-inline-start: calc(var(--border-width) * 3) solid var(--tile-accent, transparent);
+			color: var(--color-text);
+			font: inherit;
+			text-align: start;
+		}
+		/* Button normalisation only — surfaces/borders come from .tile-fragment above. */
+		.tile-fragment--clickable {
+			appearance: none;
+			inline-size: 100%;
+			cursor: pointer;
+		}
+		.tile-fragment--clickable:hover {
+			background: var(--color-surface-hover);
+		}
+		tile-header {
+			display: flex;
+			align-items: center;
+			gap: var(--gutter-xs);
+			font-weight: var(--font-semibold);
+		}
+		.tile-icon :global(svg) {
+			font-size: var(--icon-size-sm);
+		}
+		.tile-title {
+			text-transform: capitalize;
+		}
+		tile-body {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-xs);
+		}
+		tile-footer {
+			display: flex;
+			align-items: center;
+			gap: var(--gutter-xs);
+			padding-top: var(--pad-xs);
+			border-top: var(--border-width) solid var(--color-border);
+		}
+	}
+</style>

--- a/packages/idae-machine/src/lib/data-ui/fragments/index.ts
+++ b/packages/idae-machine/src/lib/data-ui/fragments/index.ts
@@ -2,6 +2,8 @@
 export { default as Skeleton } from './Skeleton.svelte';
 export { default as Selector } from './Selector.svelte';
 export { default as Frame } from './Frame.svelte';
+export { default as Tile } from './Tile.svelte';
+export { default as InfoLine } from './InfoLine.svelte';
 export { default as Dialog } from './dialog/Dialog.svelte';
 export { default as ContextMenu } from './ContextMenu.svelte';
 export { default as ContextMenuContent } from './ContextMenuContent.svelte';

--- a/packages/idae-machine/src/lib/index.ts
+++ b/packages/idae-machine/src/lib/index.ts
@@ -7,6 +7,7 @@ export * from '$lib/main/index.js';
 export { default as Explorer } from '$lib/shell/frame/explorer/Explorer.svelte';
 export { default as Diagram } from '$lib/shell/frame/diagram/Diagram.svelte';
 export { default as Today } from '$lib/shell/frame/today/Today.svelte';
+export { default as Space } from '$lib/shell/frame/space/Space.svelte';
 export { buildGraph } from '$lib/data-ui/utils/diagramUtils.js';
 export type { DiagramOptions } from '$lib/data-ui/utils/diagramUtils.js';
 
@@ -18,6 +19,7 @@ export { default as DataForm } from '$lib/data-ui/data/DataForm.svelte';
 export { default as DataRecord } from '$lib/data-ui/data/DataRecord.svelte';
 export { default as DataFk } from '$lib/data-ui/data/DataFk.svelte';
 export { default as DataRfk } from '$lib/data-ui/data/DataRfk.svelte';
+export { default as DataCount } from '$lib/data-ui/data/DataCount.svelte';
 
 // UI — frame content: card (record level)
 
@@ -32,6 +34,8 @@ export { default as Sort } from '$lib/data-ui/controls/Sort.svelte';
 export { default as Group } from '$lib/data-ui/controls/Group.svelte';
 export { default as Find } from '$lib/data-ui/controls/Find.svelte';
 export { default as ListMode } from '$lib/data-ui/controls/ListMode.svelte';
+export { default as AlphabetFilter } from '$lib/data-ui/controls/AlphabetFilter.svelte';
+export { default as FkFilter } from '$lib/data-ui/controls/FkFilter.svelte';
 
 // UI — prefs helpers
 export {
@@ -93,6 +97,8 @@ export { default as FrameFragment } from '$lib/data-ui/fragments/Frame.svelte';
 export { default as Frame } from '$lib/shell/Frame.svelte';
 export { default as Selector } from '$lib/data-ui/fragments/Selector.svelte';
 export { default as Skeleton } from '$lib/data-ui/fragments/Skeleton.svelte';
+export { default as Tile } from '$lib/data-ui/fragments/Tile.svelte';
+export { default as InfoLine } from '$lib/data-ui/fragments/InfoLine.svelte';
 export { default as ContextMenu } from '$lib/data-ui/fragments/ContextMenu.svelte';
 export { default as ContextMenuContent } from '$lib/data-ui/fragments/ContextMenuContent.svelte';
 export { openContextMenu, closeContextMenu } from '$lib/data-ui/fragments/contextMenu.svelte.js';

--- a/packages/idae-machine/src/lib/shell/frame/space/Space.svelte
+++ b/packages/idae-machine/src/lib/shell/frame/space/Space.svelte
@@ -1,11 +1,75 @@
 <!--
-Space.svelte — collection workspace frame (zone main).
-A dedicated landing page for a collection, distinct from explorer/list.
-Mounted via machine.framer.loadFrame('space', collection).
+Space.svelte — collection workspace frame (zone main). Port of the legacy
+"Espace <table>" screen (app_explorer.php + app_explorer_home*): scheme header
+(icon/name/color, Créer, vues récentes), total, classification breakdown
+(statut/type/categorie/groupe — 'END' status excluded from the denominator, as
+legacy did), forward-FK cards with orphan counts, reverse-FK "Voir aussi" grouped
+by appscheme_type, period counters (mois/semaine), and a search column (free
+text + alphabet + FK filters) narrowing the main list.
+
+Mounted via machine.framer.loadFrame('space', collection) — one instance per
+collection. Reads via machine.store (reactive); writes via machine.menu.verbs
+(machine.action under the hood). Schema (scheme.fks/scheme.fields) is static
+post-boot data, read once at setup, like Today.svelte. machine.store() registers
+a subscription at call time and must not be re-invoked inside $derived (CLAUDE.md
+invariant 10) — the classification/forward-FK option stores are therefore opened
+once, in a setup-time loop over the (fixed, per-instance) scheme.fks entries.
+
+Records store a relation either as the nested join snapshot (`record.fks.<name>` =
+{id|code}) or as a flat scalar field (`category: "compact"` — what seeded/server data
+actually holds). Classification and forward-FK aggregates therefore read through
+resolveFkKey, which tries nested then flat (via scheme.findFkField), the same order as
+dataRelationUtils.resolveForwardRelations. FkFilter emits its where against whichever
+form applies.
+
+A FK is a CLASSIFICATION when its target collection is declared `isStatus`/`isType`/
+`isGroup` (see server/src/models/agile/agileScheme.ts for the canonical shape:
+`project_status: { isStatus: true }` + `project.fkRelations.project_status`). Those
+flags are the house replacement for the legacy `<table>_statut` referential — note the
+English `_status` spelling, which publishModel also falls back on by suffix.
+
+They are read from the `appscheme` records, NOT from machine.logic: MachineServer's
+getModel() rebuilds the client model from the appscheme docs and does not carry
+isStatus/isType/isGroup over, so `machine.logic.collection(x).model.isStatus` is always
+undefined client-side. publishModel writes both the flags and the equivalent
+`fks.appscheme_type.code` ('status' | 'type' | 'group' | 'standard') onto the doc.
 -->
 <script lang="ts">
 	import Icon from '@iconify/svelte';
 	import { machine } from '$lib/main/machine.js';
+	import type { Where } from '$lib/types/index.js';
+	import DataList from '$lib/data-ui/data/DataList.svelte';
+	import DataCount from '$lib/data-ui/data/DataCount.svelte';
+	import Tile from '$lib/data-ui/fragments/Tile.svelte';
+	import InfoLine from '$lib/data-ui/fragments/InfoLine.svelte';
+	import Find from '$lib/data-ui/controls/Find.svelte';
+	import AlphabetFilter from '$lib/data-ui/controls/AlphabetFilter.svelte';
+	import FkFilter from '$lib/data-ui/controls/FkFilter.svelte';
+
+	type RecordRow = Record<string, unknown> & {
+		id?: unknown;
+		fks?: Record<string, { code?: unknown } | undefined>;
+	};
+	type HistoryRow = {
+		id?: unknown;
+		collection?: string;
+		collection_value?: unknown;
+		label?: string;
+		count?: number;
+		lastSeen?: string;
+	};
+	type AppschemeRow = {
+		code: string;
+		name?: string;
+		icon?: string;
+		color?: string;
+		isStatus?: boolean;
+		isType?: boolean;
+		isGroup?: boolean;
+		fks?: { appscheme_type?: { code?: string } };
+	};
+	type AppschemeTypeRow = { code: string; name?: string };
+	type OptionRow = { id?: unknown; code?: unknown; name?: unknown };
 
 	let {
 		collection,
@@ -17,50 +81,383 @@ Mounted via machine.framer.loadFrame('space', collection).
 		vars?: Record<string, string>;
 	} = $props();
 
-	function openExplorer(): void {
-		machine.menu.verbs.explorer?.(collection);
+	const logicScheme = machine.logic.collection(collection);
+	const canCreate = machine.rights.checkAccess(collection, 'C');
+
+	// Must stay collection-scoped: dataListPrefsScope() returns the override verbatim,
+	// so a bare 'space' would make every collection's Espace share one prefs slot
+	// (search/sort/mode bleeding across collections, persisted under a single key).
+	const prefsScope = `space.${collection}`;
+
+	// Setup-time subscriptions — see file header.
+	const schemeStore = machine.store<AppschemeRow>('appscheme', { code: collection });
+	const historyStore = machine.store<HistoryRow>('appuser_history', { collection });
+	const mainStore = machine.store<RecordRow>(collection);
+	const appschemeAllStore = machine.store<AppschemeRow>('appscheme');
+	const appschemeTypeStore = machine.store<AppschemeTypeRow>('appscheme_type');
+
+	const fksEntries = logicScheme ? Object.entries(logicScheme.fks) : [];
+
+	// Records carry an FK either as the nested join snapshot (record.fks.<name> = {id|code})
+	// or — as seed/legacy data actually does — as a flat scalar field (e.g. `category: "compact"`).
+	// scheme.findFkField resolves the flat field name/index for the fallback; see MachineScheme
+	// and dataRelationUtils.resolveForwardRelations, which apply the same nested-then-flat order.
+	function resolveFkKey(
+		record: RecordRow,
+		fkName: string,
+		fieldInfo: { fieldName: string; targetIndex: string } | null
+	): unknown {
+		const nested = record.fks?.[fkName] as { code?: unknown; id?: unknown } | undefined;
+		if (nested?.code != null) return nested.code;
+		if (nested?.id != null) return nested.id;
+		if (fieldInfo) return record[fieldInfo.fieldName];
+		return undefined;
+	}
+
+	function matchesOption(value: unknown, option: OptionRow): boolean {
+		return value != null && (value === option.code || value === option.id);
+	}
+
+	/**
+	 * Classification kind of an FK target, from its appscheme record. Explicit flags win;
+	 * `fks.appscheme_type.code` is the equivalent published form (publishModel derives it
+	 * from the same flags, falling back to the `_status`/`_type`/`_group` name suffix).
+	 * null = plain relation, rendered as a répartition card instead.
+	 */
+	function classKind(meta: AppschemeRow | undefined): 'status' | 'type' | 'group' | null {
+		if (!meta) return null;
+		if (meta.isStatus) return 'status';
+		if (meta.isType) return 'type';
+		if (meta.isGroup) return 'group';
+		const published = meta.fks?.appscheme_type?.code;
+		return published === 'status' || published === 'type' || published === 'group'
+			? published
+			: null;
+	}
+
+	// One subscription per declared FK target. The FK set is static, so opening the
+	// stores here is setup-safe; which of them counts as a classification is decided
+	// reactively below, since it depends on appscheme records loaded after boot.
+	const fkStores = fksEntries.map(([fkName, fk]) => ({
+		fkName,
+		fk,
+		fieldInfo: logicScheme?.findFkField(fk.code) ?? null,
+		optionsStore: machine.store<OptionRow>(fk.code)
+	}));
+
+	const classifiedFks = $derived.by(() => {
+		const appschemes = appschemeAllStore.records as AppschemeRow[];
+		return fkStores.map((entry) => ({
+			...entry,
+			kind: classKind(appschemes.find((s) => s.code === entry.fk.code))
+		}));
+	});
+
+	const dateFieldsStatic = logicScheme
+		? Object.keys(logicScheme.fields).filter((name) =>
+				['date', 'datetime'].includes((logicScheme.fields[name] as { type?: string })?.type ?? '')
+			)
+		: [];
+
+	const reverseFksStatic = logicScheme ? logicScheme.parseReverseFks() : {};
+	const reverseCollections = Object.keys(reverseFksStatic).filter((c) => machine.rights.checkAccess(c, 'L'));
+
+	const schemeInfo = $derived(schemeStore.records[0]);
+	const total = $derived(mainStore.records.length);
+
+	const recentHistory = $derived(
+		[...historyStore.records]
+			.sort((a, b) => String(b.lastSeen ?? '').localeCompare(String(a.lastSeen ?? '')))
+			.slice(0, 6)
+	);
+
+	const classificationPanels = $derived.by(() => {
+		const records = mainStore.records as RecordRow[];
+		return classifiedFks
+			.filter((entry) => entry.kind !== null)
+			.map(({ fkName, fk, fieldInfo, optionsStore, kind }) => {
+			const options = optionsStore.records as OptionRow[];
+			// Legacy rule kept: a closed status is excluded from the denominator, so
+			// "n sur m" measures progress over still-open records. 'END' is the closed
+			// marker in IdaeCapabilities.workflowOrder().
+			const endOption = kind === 'status' ? options.find((o) => o.code === 'END') : undefined;
+			const endCount = endOption
+				? records.filter((r) => matchesOption(resolveFkKey(r, fkName, fieldInfo), endOption)).length
+				: 0;
+			const denom = total - endCount;
+			return {
+				fkName,
+				targetCollection: fk.code,
+				options: options
+					.filter((o) => !endOption || o.code !== endOption.code)
+					.map((o) => {
+						const count = records.filter((r) => matchesOption(resolveFkKey(r, fkName, fieldInfo), o)).length;
+						return {
+							code: String(o.code ?? ''),
+							name: String(o.name ?? o.code ?? ''),
+							count,
+							denom,
+							progress: denom > 0 ? count / denom : 0
+						};
+					})
+					.filter((o) => o.count > 0)
+			};
+		});
+	});
+
+	const forwardFkPanels = $derived.by(() => {
+		const records = mainStore.records as RecordRow[];
+		const appschemes = appschemeAllStore.records as AppschemeRow[];
+		return classifiedFks
+			.filter((entry) => entry.kind === null)
+			.map(({ fkName, fk, fieldInfo }) => {
+			const keys = records.map((r) => resolveFkKey(r, fkName, fieldInfo)).filter((k) => k != null);
+			const distinct = new Set(keys).size;
+			const orphans = records.length - keys.length;
+			const meta = appschemes.find((s) => s.code === fk.code);
+			return { fkName, targetCollection: fk.code, distinct, orphans, meta };
+		});
+	});
+
+	const seeAlsoGroups = $derived.by(() => {
+		const appschemes = appschemeAllStore.records as AppschemeRow[];
+		const types = appschemeTypeStore.records as AppschemeTypeRow[];
+		const groups = new Map<string, { key: string; label: string; items: Array<{ collection: string; name: string; icon?: string }> }>();
+		for (const col of reverseCollections) {
+			const meta = appschemes.find((s) => s.code === col);
+			const typeCode = meta?.fks?.appscheme_type?.code ?? 'ungrouped';
+			const typeMeta = types.find((t) => t.code === typeCode);
+			const label = typeMeta?.name ?? (typeCode === 'ungrouped' ? 'Autres' : typeCode);
+			if (!groups.has(typeCode)) groups.set(typeCode, { key: typeCode, label, items: [] });
+			groups.get(typeCode)!.items.push({ collection: col, name: meta?.name ?? col, icon: meta?.icon });
+		}
+		return Array.from(groups.values()).sort((a, b) => a.label.localeCompare(b.label));
+	});
+
+	let periodField = $state<string | undefined>(
+		dateFieldsStatic.includes('dateDebut') ? 'dateDebut' : dateFieldsStatic[0]
+	);
+
+	function isoDate(d: Date): string {
+		return d.toISOString().slice(0, 10);
+	}
+	function startOfWeek(d: Date): Date {
+		const x = new Date(d);
+		x.setDate(x.getDate() - ((x.getDay() + 6) % 7));
+		x.setHours(0, 0, 0, 0);
+		return x;
+	}
+	function startOfMonth(d: Date): Date {
+		return new Date(d.getFullYear(), d.getMonth(), 1);
+	}
+
+	const periodCounts = $derived.by(() => {
+		if (!periodField) return [];
+		const field = periodField;
+		const now = new Date();
+		const thisWeekStart = startOfWeek(now);
+		const lastWeekStart = new Date(thisWeekStart);
+		lastWeekStart.setDate(lastWeekStart.getDate() - 7);
+		const nextWeekStart = new Date(thisWeekStart);
+		nextWeekStart.setDate(nextWeekStart.getDate() + 7);
+		const thisMonthStart = startOfMonth(now);
+		const lastMonthStart = new Date(thisMonthStart.getFullYear(), thisMonthStart.getMonth() - 1, 1);
+		const nextMonthStart = new Date(thisMonthStart.getFullYear(), thisMonthStart.getMonth() + 1, 1);
+
+		const windows = [
+			{ label: 'Mois dernier', start: isoDate(lastMonthStart), end: isoDate(thisMonthStart) },
+			{ label: 'Ce mois-ci', start: isoDate(thisMonthStart), end: isoDate(nextMonthStart) },
+			{ label: 'Semaine dernière', start: isoDate(lastWeekStart), end: isoDate(thisWeekStart) },
+			{ label: 'Cette semaine', start: isoDate(thisWeekStart), end: isoDate(nextWeekStart) }
+		];
+
+		const records = mainStore.records as RecordRow[];
+		return windows.map((w) => ({
+			...w,
+			count: records.filter((r) => {
+				const v = String(r[field] ?? '');
+				return v !== '' && v >= w.start && v < w.end;
+			}).length
+		}));
+	});
+
+	let letterWhere = $state<Where | undefined>(undefined);
+	let fkWheres = $state<Record<string, Where | undefined>>({});
+
+	const listWhere = $derived.by(() => {
+		const merged: Record<string, unknown> = {};
+		if (letterWhere) Object.assign(merged, letterWhere);
+		for (const w of Object.values(fkWheres)) if (w) Object.assign(merged, w);
+		return Object.keys(merged).length ? (merged as Where) : undefined;
+	});
+
+	function resetFilters(): void {
+		letterWhere = undefined;
+		fkWheres = {};
 	}
 
 	function openCreate(): void {
 		machine.menu.verbs.create?.(collection);
 	}
+
+	function openRecord(id: unknown): void {
+		if (id == null) return;
+		machine.menu.verbs.fiche?.(collection, id as string | number);
+	}
+
+	function openSpace(targetCollection: string): void {
+		machine.menu.verbs.space?.(targetCollection);
+	}
 </script>
 
 <space-component>
-	<space-header>
-		<h2>Espace {collection}</h2>
-		{#if collectionId != null}<span class="space-record">{collectionId}</span>{/if}
-	</space-header>
+	<space-main>
+		<space-header>
+			{#if schemeInfo?.icon}<Icon icon={schemeInfo.icon} class="space-header-icon" />{/if}
+			<h2 style={schemeInfo?.color ? `color: ${schemeInfo.color};` : undefined}>
+				{schemeInfo?.name ?? collection}
+			</h2>
+			{#if collectionId != null}<span class="space-record">{collectionId}</span>{/if}
+			{#if canCreate}
+				<button type="button" class="btn-primary" onclick={openCreate}>
+					Créer {schemeInfo?.name ?? collection}
+				</button>
+			{/if}
+			<DataCount {collection} label="Total" />
+		</space-header>
 
-	<space-actions>
-		<button type="button" class="space-tile" onclick={openExplorer}>
-			<span class="space-tile-icon"><Icon icon="ph:list" /></span>
-			<span class="space-tile-label">Parcourir {collection}</span>
-		</button>
-		<button type="button" class="space-tile" onclick={openCreate}>
-			<span class="space-tile-icon"><Icon icon="ph:plus" /></span>
-			<span class="space-tile-label">Créer {collection}</span>
-		</button>
-	</space-actions>
+		{#if recentHistory.length}
+			<space-header-recent>
+				{#each recentHistory as entry (entry.id)}
+					<button type="button" class="space-recent-item" onclick={() => openRecord(entry.collection_value)}>
+						{entry.label ?? entry.collection_value}
+					</button>
+				{/each}
+			</space-header-recent>
+		{/if}
 
-	<space-body>
-		<p class="space-empty">Espace {collection} — à enrichir.</p>
-	</space-body>
+		{#if classificationPanels.some((p) => p.options.length)}
+			<space-classifications>
+				{#each classificationPanels as panel (panel.fkName)}
+					{#if panel.options.length}
+						<Tile title={panel.fkName}>
+							{#each panel.options as option (option.code)}
+								<InfoLine
+									label={option.name}
+									value={option.count}
+									hint={`${option.count} sur ${option.denom}`}
+									progress={option.progress}
+								/>
+							{/each}
+						</Tile>
+					{/if}
+				{/each}
+			</space-classifications>
+		{/if}
+
+		{#if forwardFkPanels.length}
+			<space-repartitions>
+				{#each forwardFkPanels as panel (panel.fkName)}
+					<Tile
+						title={panel.meta?.name ?? panel.targetCollection}
+						icon={panel.meta?.icon}
+						accentColor={panel.meta?.color}
+						onclick={() => openSpace(panel.targetCollection)}
+					>
+						<span class="space-fk-count">{panel.distinct} élément(s)</span>
+						{#if panel.orphans > 0}
+							<span class="space-fk-orphans">
+								<Icon icon="ph:link-break" /> {panel.orphans} sans {panel.fkName}
+							</span>
+						{/if}
+					</Tile>
+				{/each}
+			</space-repartitions>
+		{/if}
+
+		{#if seeAlsoGroups.length}
+			<space-see-also>
+				<Tile title="Voir aussi">
+					{#each seeAlsoGroups as group (group.key)}
+						<space-see-also-group>
+							<h4>{group.label}</h4>
+							{#each group.items as item (item.collection)}
+								<button type="button" class="space-see-also-item" onclick={() => openSpace(item.collection)}>
+									{#if item.icon}<Icon icon={item.icon} />{/if}
+									{item.name}
+									<DataCount collection={item.collection} />
+								</button>
+							{/each}
+						</space-see-also-group>
+					{/each}
+				</Tile>
+			</space-see-also>
+		{/if}
+
+		{#if dateFieldsStatic.length}
+			<space-periods>
+				<Tile title="Périodes">
+					{#snippet header()}
+						<select class="form-select" bind:value={periodField}>
+							{#each dateFieldsStatic as field (field)}
+								<option value={field}>{field}</option>
+							{/each}
+						</select>
+					{/snippet}
+					{#each periodCounts as period (period.label)}
+						<InfoLine label={period.label} value={period.count} />
+					{/each}
+				</Tile>
+			</space-periods>
+		{/if}
+
+		<space-list>
+			<DataList
+				{collection}
+				where={listWhere}
+				{prefsScope}
+				sortBy={logicScheme?.defaultSort}
+				link="loadInDialog:fiche"
+				pageSize={30}
+			/>
+		</space-list>
+	</space-main>
+
+	<space-search>
+		<Find {collection} {prefsScope} />
+		<AlphabetFilter {collection} bind:where={letterWhere} />
+		{#if fksEntries.length}
+			<space-search-fk-filters>
+				{#each fksEntries as [fkName] (fkName)}
+					<FkFilter {collection} {fkName} bind:where={fkWheres[fkName]} />
+				{/each}
+			</space-search-fk-filters>
+		{/if}
+		<button type="button" class="btn-ghost" onclick={resetFilters}>Réinitialiser</button>
+	</space-search>
 </space-component>
 
 <style>
 	@layer components {
 		space-component {
-			display: flex;
-			flex-direction: column;
+			display: grid;
+			grid-template-columns: 1fr minmax(calc(var(--gutter-3xl) * 4), calc(var(--gutter-3xl) * 5.5));
 			gap: var(--gutter-sm);
 			padding: var(--pad-sm);
 			overflow-y: auto;
+			align-items: start;
+		}
+		space-main {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-sm);
+			min-width: 0;
 		}
 		space-header {
 			display: flex;
-			align-items: baseline;
+			align-items: center;
 			gap: var(--gutter-sm);
+			flex-wrap: wrap;
 		}
 		space-header h2 {
 			margin: 0;
@@ -70,43 +467,88 @@ Mounted via machine.framer.loadFrame('space', collection).
 			color: var(--color-text-muted);
 			font-size: var(--text-sm);
 		}
-		space-actions {
+		space-header-recent {
 			display: flex;
-			gap: var(--gutter-sm);
+			gap: var(--gutter-xs);
 			flex-wrap: wrap;
 		}
-		.space-tile {
+		.space-recent-item {
 			all: unset;
+			cursor: pointer;
+			padding: var(--pad-xs) var(--pad-sm);
+			border-radius: var(--radius-full);
+			background: var(--color-surface-alt);
+			font-size: var(--text-xs);
+			color: var(--color-text-muted);
+		}
+		.space-recent-item:hover {
+			background: var(--color-surface-hover);
+			color: var(--color-text);
+		}
+		space-classifications,
+		space-repartitions {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(calc(var(--gutter-3xl) * 4), 1fr));
+			gap: var(--gutter-sm);
+		}
+		.space-fk-count {
+			font-weight: var(--font-semibold);
+		}
+		.space-fk-orphans {
+			display: inline-flex;
+			align-items: center;
+			gap: var(--gutter-xs);
+			color: var(--color-critical);
+			font-size: var(--text-sm);
+		}
+		space-see-also {
+			display: block;
+		}
+		space-see-also-group {
 			display: flex;
 			flex-direction: column;
-			align-items: center;
-			justify-content: center;
 			gap: var(--gutter-xs);
-			width: calc(var(--gutter-3xl) * 1.75);
-			height: calc(var(--gutter-3xl) * 1.75);
+		}
+		space-see-also-group h4 {
+			margin: 0;
+			font-size: var(--text-xs);
+			text-transform: uppercase;
+			color: var(--color-text-muted);
+		}
+		.space-see-also-item {
+			all: unset;
+			display: flex;
+			align-items: center;
+			gap: var(--gutter-xs);
+			cursor: pointer;
+			padding: var(--pad-xs) var(--pad-sm);
+			border-radius: var(--radius-xs);
+		}
+		.space-see-also-item:hover {
+			background: var(--color-surface-hover);
+		}
+		space-periods {
+			display: block;
+		}
+		space-list {
+			display: block;
+			min-block-size: 0;
+		}
+		space-search {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-sm);
+			position: sticky;
+			top: 0;
 			padding: var(--pad-sm);
 			border: var(--border-width) solid var(--color-border);
 			border-radius: var(--radius-xs);
 			background: var(--color-surface-alt);
-			color: var(--color-text);
-			cursor: pointer;
-			text-align: center;
 		}
-		.space-tile:hover {
-			background: var(--color-surface-hover);
-		}
-		.space-tile-icon :global(svg) {
-			font-size: var(--icon-size-md);
-		}
-		.space-tile-label {
-			font-size: var(--text-sm);
-			line-height: var(--leading-tight);
-		}
-		space-body {
-			display: block;
-		}
-		.space-empty {
-			color: var(--color-text-muted);
+		space-search-fk-filters {
+			display: flex;
+			flex-direction: column;
+			gap: var(--gutter-sm);
 		}
 	}
 </style>

--- a/packages/idae-machine/src/lib/shell/frame/space/Space.svelte.test.ts
+++ b/packages/idae-machine/src/lib/shell/frame/space/Space.svelte.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression guard for Space's classification detection.
+ *
+ * A FK counts as a classification when its TARGET collection is declared
+ * isStatus/isType/isGroup (agileScheme's `project_status: { isStatus: true }` shape),
+ * not when its name happens to start with the owning collection's name. Those flags
+ * live only on the `appscheme` records: MachineServer.getModel() rebuilds the client
+ * model from those docs and drops isStatus/isType/isGroup, so reading them off
+ * machine.logic would always yield undefined and silently render nothing.
+ *
+ * Relations resolve the same way (FKRELATIONS.md) — from `appscheme.fkRelations`, not
+ * the in-memory model — hence the appscheme seeding below, mirroring publishModel.
+ *
+ * The cases pin that contract: a same-prefix-but-unflagged collection must NOT be
+ * treated as a classification, a flagged one must be, and the legacy 'END' denominator
+ * rule must apply to statuses only.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { flushSync, tick } from 'svelte';
+import { cleanup, render } from '@testing-library/svelte';
+import type { MachineModel } from '$lib/types/index.js';
+import { machine } from '$lib/main/machine.js';
+import { resetIndexedDB, uniqueDbName, withAppscheme } from '$lib/main/__tests__/_relationTestUtils.js';
+import Space from './Space.svelte';
+
+const referential = () => ({
+	keyPath: '++id',
+	base: 'machine_base',
+	model: {},
+	fields: {
+		id:   { type: 'id', readonly: true },
+		code: { type: 'text', required: true },
+		name: { type: 'text' }
+	},
+	fkRelations: {},
+	template: { presentation: 'name code' }
+});
+
+const model = {
+	appscheme_type: referential(),
+	appuser_history: {
+		keyPath: '++id',
+		base: 'machine_user',
+		model: {},
+		fields: {
+			id:               { type: 'id', readonly: true },
+			code:             { type: 'text' },
+			collection:       { type: 'text' },
+			collection_value: { type: 'text' },
+			label:            { type: 'text' },
+			lastSeen:         { type: 'text' }
+		},
+		fkRelations: {},
+		template: { presentation: 'label' }
+	},
+	// Flagged status referential.
+	task_status: referential(),
+	// Same `task_` prefix but NOT a classification — the old heuristic wrongly matched it.
+	task_attachment: referential(),
+	task: {
+		keyPath: '++id',
+		base: 'machine_base',
+		model: {},
+		fields: {
+			id:   { type: 'id', readonly: true },
+			code: { type: 'text', required: true },
+			name: { type: 'text' }
+		},
+		fkRelations: {
+			task_status:     { code: 'task_status' },
+			task_attachment: { code: 'task_attachment' }
+		},
+		template: { presentation: 'name code' }
+	}
+} as unknown as MachineModel;
+
+/** Flags publishModel would stamp onto the appscheme doc, keyed by collection code. */
+const SCHEME_FLAGS: Record<string, Record<string, unknown>> = {
+	task_status: { isStatus: true }
+};
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 3; i += 1) {
+		flushSync();
+		await tick();
+	}
+}
+
+function panelTitles(container: HTMLElement, zone: string): string[] {
+	return [...container.querySelectorAll(`${zone} .tile-title`)].map((n) => n.textContent?.trim() ?? '');
+}
+
+describe('Space — classification detection', () => {
+	beforeEach(async () => {
+		resetIndexedDB();
+		machine.destroy();
+		machine.init({ dbName: uniqueDbName('space-classif'), version: 1, business: withAppscheme(model) });
+		await machine.boot();
+
+		// Mirror publishModel: relations AND classification flags live on appscheme.
+		for (const [code, def] of Object.entries(model)) {
+			await machine.collection('appscheme').create({
+				code,
+				name: code,
+				fkRelations: (def as { fkRelations?: unknown }).fkRelations ?? {},
+				...(SCHEME_FLAGS[code] ?? {})
+			});
+		}
+
+		await machine.collection('task_status').create({ code: 'OPEN', name: 'Ouvert' });
+		await machine.collection('task_status').create({ code: 'END', name: 'Terminé' });
+		await machine.collection('task_attachment').create({ code: 'DOC', name: 'Document' });
+
+		// 4 tasks, 2 of them END → status denominator excludes them → "1 sur 2".
+		await machine.collection('task').create({ code: 't1', name: 'A', fks: { task_status: { code: 'OPEN' } } });
+		await machine.collection('task').create({ code: 't2', name: 'B', fks: { task_status: { code: 'END' } } });
+		await machine.collection('task').create({ code: 't3', name: 'C', fks: { task_status: { code: 'END' } } });
+		await machine.collection('task').create({ code: 't4', name: 'D', fks: { task_attachment: { code: 'DOC' } } });
+	});
+
+	afterEach(() => {
+		cleanup();
+		machine.destroy();
+	});
+
+	it('classifies a flagged target and leaves a same-prefix unflagged one as a répartition', async () => {
+		const { container } = render(Space, { collection: 'task' });
+		await settle();
+
+		expect(panelTitles(container, 'space-classifications')).toEqual(['task_status']);
+		expect(panelTitles(container, 'space-repartitions')).toContain('task_attachment');
+	});
+
+	it('excludes the END status from the denominator and hides the END option', async () => {
+		const { container } = render(Space, { collection: 'task' });
+		await settle();
+
+		const lines = [...container.querySelectorAll('space-classifications info-line-fragment')].map(
+			(n) => n.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+		);
+
+		expect(lines.some((l) => l.includes('Ouvert') && l.includes('1 sur 2'))).toBe(true);
+		expect(lines.some((l) => l.includes('Terminé'))).toBe(false);
+	});
+});

--- a/packages/idae-machine/src/lib/shell/frame/today/Today.svelte
+++ b/packages/idae-machine/src/lib/shell/frame/today/Today.svelte
@@ -11,6 +11,7 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 <script lang="ts">
 	import { machine } from '$lib/main/machine.js';
 	import { useMenuTree } from '$lib/data-ui/utils/useMenuTree.svelte.js';
+	import Tile from '$lib/data-ui/fragments/Tile.svelte';
 
 	type RecordRow = Record<string, unknown> & {
 		id?: unknown;
@@ -77,8 +78,7 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 </script>
 
 <today-dashboard-component>
-	<today-section data-section="create">
-		<h3>Créer</h3>
+	<Tile title="Créer">
 		<today-create>
 			{#each createMenu.tree.groups as group (group.key)}
 				{#each group.items as item (item.key)}
@@ -91,10 +91,9 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 				<span class="today-empty">—</span>
 			{/each}
 		</today-create>
-	</today-section>
+	</Tile>
 
-	<today-section data-section="my-lists">
-		<h3>Mes listes</h3>
+	<Tile title="Mes listes">
 		<today-my-lists>
 			{#each myLists as group (group.collection)}
 				<today-my-lists-group>
@@ -107,10 +106,9 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 				<span class="today-empty">—</span>
 			{/each}
 		</today-my-lists>
-	</today-section>
+	</Tile>
 
-	<today-section data-section="echeancier">
-		<h3>Échéancier</h3>
+	<Tile title="Échéancier">
 		<today-echeancier>
 			{#each echeancier as entry (`${entry.collection}:${entry.record.id ?? entry.record.code}`)}
 				<div class="today-echeancier-item">
@@ -121,7 +119,7 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 				<span class="today-empty">—</span>
 			{/each}
 		</today-echeancier>
-	</today-section>
+	</Tile>
 </today-dashboard-component>
 
 <style>
@@ -131,11 +129,6 @@ machine.logic.collections() (static post-boot schema), never re-joined per rende
 			grid-template-columns: repeat(auto-fit, minmax(calc(var(--gutter-3xl) * 4), 1fr));
 			gap: var(--gutter-sm);
 			padding: var(--pad-sm);
-		}
-		today-section {
-			display: flex;
-			flex-direction: column;
-			gap: var(--gutter-xs);
 		}
 		today-create {
 			display: flex;


### PR DESCRIPTION
- Introduced InfoLine.svelte for displaying label/value lines with optional hints and progress bars.
- Added Tile.svelte to serve as a generic card/section shell with title, icon, and optional footer.
- Updated fragments index to export new Tile and InfoLine components.
- Enhanced Space.svelte to utilize Tile and InfoLine for better classification and display of data.
- Refactored Today.svelte to replace section headers with Tile components for consistency in UI.
- Implemented tests for Space.svelte to ensure correct classification detection and behavior.