### PR TITLE
chore(deps): bump idae-pnpm-release to 1.0.46 (dependency-ordered builds)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,14 @@
 {
-	"permissions": {
-		"allow": ["Bash(cat:*)", "Bash(node:*)"]
-	}
+  "permissions": {
+    "allow": [
+      "Bash(cat:*)",
+      "Bash(node:*)",
+      "Bash(gh run *)",
+      "Bash(pnpm -r run build --if-present)",
+      "Bash(sed 's/^Release and Publish\\\\tUNKNOWN STEP\\\\t//')",
+      "Bash(git rm *)",
+      "Bash(git fetch *)",
+      "Bash(npm view *)"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@medyll/css-base": "link:../css-base",
-    "@medyll/idae-pnpm-release": "^1.0.45",
+    "@medyll/idae-pnpm-release": "^1.0.46",
     "@medyll/monorepo-pnpm-release": "^1.0.22",
     "@octokit/rest": "^22.0.1",
     "chalk": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: link:../css-base
         version: link:../css-base
       '@medyll/idae-pnpm-release':
-        specifier: ^1.0.45
-        version: 1.0.45(@pnpm/logger@5.2.0)
+        specifier: ^1.0.46
+        version: 1.0.46(@pnpm/logger@5.2.0)
       '@medyll/monorepo-pnpm-release':
         specifier: ^1.0.22
         version: 1.0.22(@pnpm/logger@5.2.0)
@@ -3525,8 +3525,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0-next
 
-  '@medyll/idae-pnpm-release@1.0.45':
-    resolution: {integrity: sha512-dQuZj+bNtjZ+iSo2/NdDkdUpjHDT0Pq9mRNoIL3YJCEeQS6rEHY00GOjh7ILI9j9zpHIcYsBp4Wx3iROdyK9bw==}
+  '@medyll/idae-pnpm-release@1.0.46':
+    resolution: {integrity: sha512-qLnW4NrvxaoCMKVMKoKuXsfd943mHGZ0n4yyj0jOVaN56TfH/8/0urJ3LkGMt0b+tyDdcUISTaGOvt7WlNnKdA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10242,8 +10242,8 @@ packages:
       - validate-npm-package-name
       - which
 
-  npm@11.18.0:
-    resolution: {integrity: sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==}
+  npm@11.19.0:
+    resolution: {integrity: sha512-SDd/hHg3KqHE5Ht2NHWxNYNtqCQ2pXAPLl6OtQhPyED5PHsRfrOtO199MZTIG2cQoQ1ZRI9t28shrD+2cr3AAw==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     bundledDependencies:
@@ -15041,7 +15041,7 @@ snapshots:
       - ws
       - zod
 
-  '@medyll/idae-pnpm-release@1.0.45(@pnpm/logger@5.2.0)':
+  '@medyll/idae-pnpm-release@1.0.46(@pnpm/logger@5.2.0)':
     dependencies:
       '@pnpm/find-workspace-packages': 6.0.9(@pnpm/logger@5.2.0)
       commander: 14.0.3
@@ -16397,7 +16397,7 @@ snapshots:
       lodash-es: 4.18.1
       nerf-dart: 1.0.0
       normalize-url: 9.0.1
-      npm: 11.18.0
+      npm: 11.19.0
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
@@ -16416,7 +16416,7 @@ snapshots:
       lodash-es: 4.18.1
       nerf-dart: 1.0.0
       normalize-url: 9.0.1
-      npm: 11.18.0
+      npm: 11.19.0
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
@@ -22944,7 +22944,7 @@ snapshots:
 
   npm@11.12.0: {}
 
-  npm@11.18.0: {}
+  npm@11.19.0: {}
 
   nth-check@2.1.1:
     dependencies:


### PR DESCRIPTION
Follow-up to #123. That release finally detected all 20 workspace packages, then failed while building them.

## What broke

`executePrePublishCommands` iterated packages in discovery order, with no topological sort. `idae-html` landed at position 7 and `idae-stator` at 15, so html was built before stator had produced `dist/`:

```
src/lib/core-engine.ts(5,24): error TS2307: Cannot find module
'@medyll/idae-stator' or its corresponding type declarations.
```

The bug was latent until #123: before that, the tool only ever processed a single package, so ordering never mattered.

Fixed in `@medyll/idae-pnpm-release@1.0.46` — topological sort over workspace siblings taking part in the same run (dependencies, devDependencies, peerDependencies), tolerant of cycles and external deps.

Verified against this workspace: stator now precedes html, same set of 20 packages, no dependency ordered after its consumer.

## Expected outcome

Same as #123, now with a build order that holds:

- 20 packages published, each a single patch bump
- `@medyll/<pkg>@<version>` tags created for the first time
- Large CHANGELOG on this pass only
- First-time publishes: `idae-router`, `idae-sync`, `qoolie`, `idae-machine-server`, `idae-eslint-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAukczEiG8ooiZ2CoDngAY