### PR TITLE
fix(deps): drop unpublished monorepo-pnpm-release dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "dependencies": {
     "@medyll/css-base": "link:../css-base",
     "@medyll/idae-pnpm-release": "^1.0.46",
-    "@medyll/monorepo-pnpm-release": "^1.0.22",
     "@octokit/rest": "^22.0.1",
     "chalk": "^5.6.2",
     "glob": "^13.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
       '@medyll/idae-pnpm-release':
         specifier: ^1.0.46
         version: 1.0.46(@pnpm/logger@5.2.0)
-      '@medyll/monorepo-pnpm-release':
-        specifier: ^1.0.22
-        version: 1.0.22(@pnpm/logger@5.2.0)
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -3530,10 +3527,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@medyll/monorepo-pnpm-release@1.0.22':
-    resolution: {integrity: sha512-ni7pALVwhkpa1p6bDw7v2CQqWVLrNaYfh4is8NtJUQKZutsdvvIlLchTxARxKdP+m72lURfwCTe4xGPb7S5X8w==}
-    hasBin: true
-
   '@modelcontextprotocol/sdk@1.11.0':
     resolution: {integrity: sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==}
     engines: {node: '>=18'}
@@ -6927,11 +6920,6 @@ packages:
   conventional-commits-parser@4.0.0:
     resolution: {integrity: sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==}
     engines: {node: '>=14'}
-    hasBin: true
-
-  conventional-commits-parser@6.2.1:
-    resolution: {integrity: sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==}
-    engines: {node: '>=18'}
     hasBin: true
 
   conventional-commits-parser@6.4.0:
@@ -13791,7 +13779,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13960,7 +13948,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14329,7 +14317,7 @@ snapshots:
   '@eslint/config-array@0.23.3':
     dependencies:
       '@eslint/object-schema': 3.0.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -15048,16 +15036,6 @@ snapshots:
       conventional-commits-parser: 6.4.0
       execa: 9.6.1
       semver: 7.8.5
-    transitivePeerDependencies:
-      - '@pnpm/logger'
-
-  '@medyll/monorepo-pnpm-release@1.0.22(@pnpm/logger@5.2.0)':
-    dependencies:
-      '@pnpm/find-workspace-packages': 6.0.9(@pnpm/logger@5.2.0)
-      commander: 14.0.3
-      conventional-commits-parser: 6.2.1
-      execa: 9.6.1
-      semver: 7.7.3
     transitivePeerDependencies:
       - '@pnpm/logger'
 
@@ -19091,10 +19069,6 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
 
-  conventional-commits-parser@6.2.1:
-    dependencies:
-      meow: 13.2.0
-
   conventional-commits-parser@6.4.0:
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -19426,6 +19400,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -19727,7 +19705,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.27.5):
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       esbuild: 0.27.5
     transitivePeerDependencies:
       - supports-color
@@ -19980,7 +19958,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -21241,7 +21219,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Follow-up to #124, which failed during install rather than build.

```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@medyll/monorepo-pnpm-release/-/monorepo-pnpm-release-1.0.22.tgz: Not Found
```

`@medyll/monorepo-pnpm-release` is not on npm at all — 404 on every version. It is the former name of `idae-pnpm-release`, sitting right next to it in the root dependencies, and nothing in the repo imports it.

CI installs kept working only because the tarball was in the runner's pnpm cache (`reused 2000` in earlier runs). Bumping the release tool changed the lockfile, invalidated the cache key (`reused 0`), and the install had to fetch it for real.

Also audited the remaining external `@medyll` deps: `css-base@^0.7.10` and `cssfabric@0.2.1-beta.9` both resolve (the latter is a prerelease, hence not `latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAukczEiG8ooiZ2CoDngAY