### PR TITLE
fix(machine-server): publish as a public package

### DIFF
--- a/packages/idae-machine/server/package.json
+++ b/packages/idae-machine/server/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@medyll/idae-machine-server",
   "version": "2.0.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "idae-machine v2 server - API and sync layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Last failure of the 19/20 release: E402, the only package missing publishConfig.access public.