### PR TITLE
fix(deps): restore css-base semver range in published packages

### DIFF
--- a/packages/idae-machine/package.json
+++ b/packages/idae-machine/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "@iconify-json/ph": "^1.2.2",
     "@iconify/svelte": "^5.2.2",
-    "@medyll/css-base": "link:..\\..\\..\\css-base",
+    "@medyll/css-base": "^0.7.10",
     "@medyll/idae-api": "workspace:*",
     "@medyll/idae-be": "workspace:*",
     "@medyll/idae-idbql": "workspace:*",

--- a/packages/idae-machine/server/package.json
+++ b/packages/idae-machine/server/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",
-    "@medyll/css-base": "link:..\\..\\..\\..\\css-base",
+    "@medyll/css-base": "^0.7.10",
     "@medyll/idae-api": "workspace:*",
     "@medyll/idae-socket": "workspace:*",
     "@medyll/qoolie": "workspace:*",


### PR DESCRIPTION
Fixes the publish failure from #127.

The dependency sweep let pnpm rewrite `@medyll/css-base` from `^0.7.10` to a `link:` specifier in `idae-machine` and `idae-machine-server`, propagated from the root manifest which legitimately links a sibling checkout. Publishing then failed publint:

```
1. The "@medyll/css-base" dependency references "link:..\..\..\css-base"
   that will likely not work when installed by end-users.
```

Both are back on `^0.7.10`. The root manifest keeps its `link:` — it is `private` and never published, and it was already that way before the sweep.

Audited every manifest in the workspace: no other `link:` or `file:` specifier remains in a published package.

Verified: `prepack` (svelte-package + publint) reports **All good!**, and `idae-slotui-svelte` packages cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAukczEiG8ooiZ2CoDngAY