### PR TITLE
fix(qoolie,machine-server): build packages before publishing them

### DIFF
--- a/packages/idae-machine/server/package.json
+++ b/packages/idae-machine/server/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "dev": "tsx --watch src/index.ts",
     "build": "tsc",
-    "package": "tsc",
+    "// package": "Workspace deps (idae-api, qoolie, idae-socket, idae-db) only resolve once their dist/ exists. On CI they are not necessarily part of the release set, so nothing builds them first and tsc fails with TS2307. Build them explicitly first.",
+    "package": "pnpm --filter \"@medyll/idae-machine-server^...\" run --if-present package && tsc",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "start": "node dist/server/src/index.js",
     "test": "vitest run",

--- a/packages/qoolie/package.json
+++ b/packages/qoolie/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*"
+  ],
   "bin": {
     "qoolie": "./dist/cli/index.js",
     "add-skill": "./dist/cli/add-skill.js"
@@ -34,6 +39,8 @@
   },
   "scripts": {
     "build": "tsc",
+    "// package": "The release tool runs 'package' before publishing and skips packages that lack it — which is why 0.0.2 shipped with no dist/ and an unresolvable main.",
+    "package": "tsc",
     "test": "vitest run",
     "test:unit": "vitest run",
     "lint": "eslint src",

--- a/packages/qoolie/tsconfig.json
+++ b/packages/qoolie/tsconfig.json
@@ -17,6 +17,11 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"]
   },
-  "include": ["src/index.ts", "src/lib/**/*", "src/cli/**/*", "src/react/**/*", "src/vue/**/*", "src/test/**/*"],
+  // devtools/ backs the "./devtools" export subpath; leaving it out of the
+  // emit made that entry point resolve to a missing file.
+  // adapters/ stays out on purpose: those are .svelte.ts files using runes
+  // ($state/$effect), which plain tsc cannot compile — emitting them needs
+  // svelte-package. The "./svelte" subpath is therefore still unbuilt.
+  "include": ["src/index.ts", "src/lib/**/*", "src/cli/**/*", "src/react/**/*", "src/vue/**/*", "src/test/**/*", "src/devtools/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Fixes the release failure from #129.

## What happened

machine-server's new `package` script finally ran on CI and could not resolve `@medyll/idae-api`, `qoolie`, `idae-socket` or `idae-db` (TS2307). Those are workspace dependencies whose `dist/` does not exist on a clean runner, and they were not part of the detected release set, so nothing built them first. Locally it passed only because their `dist/` lingered from earlier builds.

machine-server now builds its workspace dependencies before compiling.

## qoolie had the same defect one level down

qoolie has no `package` script, so the release tool skipped it exactly as it skipped machine-server. **`@medyll/qoolie@0.0.2` on npm is a 137-file tarball with no `dist/` and an unresolvable `main`** — the package cannot be imported at all. It now defines `package` and `files: ["dist"]`.

Its tsconfig also left `src/devtools` out of the emit while `package.json` advertised a `./devtools` export, so that subpath pointed at a missing file. Now included.

## Verification

From a cold tree (`dist/` removed from all four dependencies):

- machine-server packages successfully
- qoolie's tarball goes from **0/9 to 7/9** declared entry points resolving
- full idae-machine gate green (804 client, 310 server, svelte-check 0 errors)

## Known remaining gaps in qoolie

Both pre-existing, both out of reach of a build fix:

| Target | Why |
|---|---|
| `exports["./svelte"]` | needs `svelte-package` — the adapters are `.svelte.ts` files using runes, which plain `tsc` cannot compile |
| `bin["add-skill"]` | points at `src/cli/add-skill.ts`, which does not exist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAukczEiG8ooiZ2CoDngAY