### PR TITLE
fix(qoolie): drop the add-skill bin, which never had a source

### DIFF
--- a/packages/qoolie/package.json
+++ b/packages/qoolie/package.json
@@ -11,8 +11,7 @@
     "!dist/**/*.spec.*"
   ],
   "bin": {
-    "qoolie": "./dist/cli/index.js",
-    "add-skill": "./dist/cli/add-skill.js"
+    "qoolie": "./dist/cli/index.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
`bin.add-skill` pointed at `./dist/cli/add-skill.js`, built from `src/cli/add-skill.ts` — a file that has never existed in this package. Every other package in the monorepo declaring that bin does ship `src/lib/cli/add-skill.js`; qoolie only ever had the declaration.

The consequence was a dead symlink on install, and a `Failed to create bin ... add-skill ENOENT` warning on every `pnpm install`, in every package depending on qoolie — the recurring install noise visible throughout the CI logs.

Removing the declaration clears them: an install now reports **no bin warnings at all**.

Nothing regresses. The command was unusable in every published version — first because no `dist/` was shipped, then because the source was absent.

All **14/14** declared entry points in the packed tarball now resolve. Full idae-machine gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAukczEiG8ooiZ2CoDngAY