### PR TITLE
feat(idae-be): 1.97.0 — TODO roadmap (events delegation, forms, effects, http robustness, position metrics) + 0 erreur TS

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "Bash(sed 's/^Release and Publish\\\\tUNKNOWN STEP\\\\t//')",
       "Bash(git rm *)",
       "Bash(git fetch *)",
-      "Bash(npm view *)"
+      "Bash(npm view *)",
+      "Bash(grep -l 'declare function $state' node_modules/.pnpm/svelte@5.50.0/node_modules/svelte/types/index.d.ts)",
+      "Bash(grep -c 'declare function $state\\\\|$state:' node_modules/.pnpm/svelte@5.50.0/node_modules/svelte/types/index.d.ts)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ coverage
 .skiller/
 
 # claude
-.claude\settings.local.json
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ coverage
 # Skiller evaluation sessions
 .skiller/
 
+# claude
+.claude\settings.local.json

--- a/packages/idae-be/CHANGELOG.md
+++ b/packages/idae-be/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.97.0] - 2026-08-07
+**Features:**
+- events: delegated on/off overloads — on(event, selector, handler) fires only when the target matches a descendant selector; handler invoked with the matched element; removable via the same (event, selector, handler) triple
+- forms: new FormHandler — serializeForm (query string or asJSON), fieldValue (per-field-type extraction), getFormElements
+- effects: new EffectsHandler — fade/appear/slideUp/slideDown/move/scale on the native Web Animations API with a synchronous fallback when el.animate is unavailable
+- http: onFailure/timeout/params on updateHttp/insertHttp and Be.fetch — error bodies are no longer injected and network failures no longer reject silently
+- position: getDimensions (display:none aware), cumulativeOffset, viewportOffset
+- utils: toArray/toWords/range collection helpers; createClass/extendObject runtime class helpers
+- docs: README, SKILL.md and api-reference updated for all new modules
+
+**Fixes:**
+- walk: methodize() now returns the root Be (callback-only contract) instead of the found elements — up/next/previous/children/closest/firstChild/lastChild no longer allow jQuery-style chaining off their return value
+- styles: get() reads inline styles only and returns null when unset, matching its documented contract
+- types: resolve all outstanding TypeScript errors (strict tsc now passes with 0 errors)
+
+**Breaking changes:**
+- walk traversal methods (up/next/previous/children/closest/firstChild/lastChild/findAll) always return the root; results must be read through the callback
+- updateHttp/insertHttp without onFailure now throw on non-ok responses instead of injecting the error body
+- Be.fetch now throws on non-ok responses instead of parsing the error body as JSON
+- getStyle no longer falls back to getComputedStyle; it reads inline styles only
+
+
 ## [1.96.3] - 2026-07-29
 **Features:**
 - add Playwright screenshot scripts and stubs for server-only packages

--- a/packages/idae-be/README.md
+++ b/packages/idae-be/README.md
@@ -13,9 +13,14 @@ npm install @medyll/idae-be
 - Root object persistence for consistent chaining
 - Callback-based element manipulation for precise targeting
 - Comprehensive DOM traversal and manipulation
-- Event handling, style management, and attribute control
+- Event handling with **event delegation** (`on(event, selector, handler)`)
+- Form serialization and per-field value access (`serializeForm`, `fieldValue`)
+- Animation helpers on the native Web Animations API (`fade`, `slideUp`, `move`, `scale`…)
+- Style management, and attribute control
+- Position measurement (`getDimensions`, `cumulativeOffset`, `viewportOffset`) and snapping
 - Timer integration for dynamic operations
-- HTTP content loading and insertion
+- HTTP content loading with failure handling, timeouts and query params
+- Standalone utilities: `toArray`, `toWords`, `range`, `createClass`, `extendObject`
 
 ## Unique Approach
 
@@ -203,17 +208,21 @@ const newElement = createBe('div', { className: 'my-class' });
 
 ### HTTP Methods
 
-#### `updateHttp(url: string, callback?: HandlerCallBackFn): Be`
-Loads content from a URL and updates the element's content.
+#### `updateHttp(url: string, options?: HttpRequestOptions, callback?: HandlerCallBackFn): Promise<Be>`
+Loads content from a URL and updates the element's content. Options: `method`, `data`, `headers`, `params` (query string), `timeout` (aborts after N ms), `onFailure(response, error?)` — called instead of the content callback on non-ok responses or network errors; without it, failures throw and error bodies are never injected.
 
 **Example:**
 ```javascript
-be('#test').updateHttp('/content.html', ({ be }) => {
+be('#test').updateHttp('/content.html', {
+    params: { section: 'news' },
+    timeout: 5000,
+    onFailure: (response) => console.error('Load failed', response?.status)
+}, ({ be }) => {
     console.log(be.html);
 });
 ```
 
-#### `insertHttp(url: string, mode?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend', callback?: HandlerCallBackFn): Be`
+#### `insertHttp(url: string, mode?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend', options?: { params?, timeout?, onFailure? }, callback?: HandlerCallBackFn): Promise<Be>`
 Loads content from a URL and inserts it into the element at a specified position.
 
 **Example:**
@@ -354,12 +363,23 @@ Add an event listener to an element.
 be('#test').on('click', () => console.log('Clicked!'));
 ```
 
+#### `on(eventName: string, selector: string, handler: EventListener): Be`
+Delegated listener: binds once on the element, fires only when the actual event target matches a descendant fitting `selector`. The handler runs with `this` set to the matched descendant — works for elements added after binding.
+
+**Example:**
+```javascript
+be('#list').on('click', 'li.item', function () {
+    be(this).toggleClass('selected');
+});
+```
+
 #### `off(eventName: string, handler: EventListener): Be`
-Remove an event listener from an element.
+Remove an event listener from an element. For delegated listeners, use `off(eventName, selector, handler)` with the same triple used at binding time.
 
 **Example:**
 ```javascript
 be('#test').off('click', handler);
+be('#list').off('click', 'li.item', handler);
 ```
 
 #### `fire(eventName: string, detail?: any): Be`
@@ -372,6 +392,82 @@ be('#test').fire('customEvent', { key: 'value' });
 
 ---
 
+### Forms
+
+#### `serializeForm(options?: { asJSON?: boolean }): string | Record<string, unknown>`
+Serialize a form to a query string (default) or a plain object (`asJSON`). Disabled, nameless, unchecked and button/file fields are skipped; multi-selects produce repeated entries or arrays.
+
+**Example:**
+```javascript
+be('#myForm').serializeForm();                 // "name=john&tags=a&tags=b"
+be('#myForm').serializeForm({ asJSON: true }); // { name: 'john', tags: ['a', 'b'] }
+```
+
+#### `fieldValue(): string | string[] | boolean`
+Get a single field's value — checkbox/radio → checked state, `<select multiple>` → array of values, anything else → `.value`.
+
+#### `getFormElements(): HTMLElement[]`
+Get the form's elements (`Array.from(form.elements)`).
+
+---
+
+### Effects
+
+Animation helpers on the native Web Animations API — no dependency. Each takes `{ duration?, easing?, delay? }` and an optional callback fired on finish; when `el.animate` is unavailable, the final state applies synchronously.
+
+#### `fade(options?, callback?): Be` / `appear(options?, callback?): Be`
+Fade out (then `display: none`) / fade in.
+
+#### `slideUp(options?, callback?): Be` / `slideDown(options?, callback?): Be`
+Collapse / expand vertically.
+
+#### `move({ x, y, ...options }, callback?): Be`
+Translate by an offset, left applied.
+
+#### `scale({ from, to, ...options }, callback?): Be`
+Scale between two factors, left applied.
+
+**Example:**
+```javascript
+be('#toast').appear({ duration: 200 });
+be('#panel').slideUp({ duration: 300 }, () => console.log('collapsed'));
+```
+
+---
+
+### Position measurement
+
+#### `getDimensions(callback): Be`
+`{ width, height }` via the callback fragment — `display: none` elements are temporarily made measurable, then restored.
+
+#### `cumulativeOffset(callback): Be`
+`{ left, top }` relative to the document (accounts for scroll).
+
+#### `viewportOffset(callback): Be`
+`{ left, top }` relative to the viewport.
+
+**Example:**
+```javascript
+be('#box').getDimensions(({ fragment }) => console.log(fragment)); // { width: 120, height: 40 }
+```
+
+---
+
+### Utilities
+
+Standalone exports (plain functions, not handlers):
+
+```javascript
+import { toArray, toWords, range, createClass, extendObject } from '@medyll/idae-be';
+
+toArray(document.querySelectorAll('div')); // HTMLElement[]
+toWords('  alpha  beta ');                 // ['alpha', 'beta']
+range(1, 4);                               // [1, 2, 3, 4]
+createClass({ initialize(name) { this.name = name; } }); // runtime class builder
+extendObject({ a: 1 }, { b: 2 });          // { a: 1, b: 2 }
+```
+
+---
 
 ## Architecture
 

--- a/packages/idae-be/TODO.md
+++ b/packages/idae-be/TODO.md
@@ -1,0 +1,246 @@
+# TODO
+
+Aimed at an implementing agent. Read `src/lib/be.ts` and
+`src/lib/modules/events.ts` first — every section below assumes the pattern
+they establish and does not re-explain it.
+
+## The pattern (read this before touching anything)
+
+Every capability is a handler class in `src/lib/modules/*.ts`:
+
+- `export class XHandler implements CommonHandler<XHandler, XHandlerHandle>`
+- `private beElement: Be` set in the constructor
+- `static methods = Object.values(xMethods)` — an enum of the method names
+  this handler exposes on `Be` (see `events.ts`'s `enum eventsMethods`)
+- `methods: string[] = XHandler.methods` — instance copy, required by
+  `CommonHandler`
+- `handle(actions: XHandlerHandle): Be` — object-literal dispatch: iterate
+  `Object.entries(actions)`, switch on the method name, call the matching
+  method, return `this.beElement`
+- One method per capability, each: iterates `this.beElement.eachNode((el) =>
+  {...})`, does the work, calls `callback?.({ fragment, be: be(el), root:
+  this.beElement })` per node, and **returns `this.beElement` — the root,
+  always**. idae-be is callback-based, not jQuery-style: results are reached
+  through `callback`'s `be`, never by chaining off the return value. See §1.
+- `valueOf()` — returns whatever makes sense as this handler's scalar value
+  (see `position.ts`: a `DOMRect`; `events.ts`: `this.beElement`)
+
+Wiring into `Be` (`src/lib/be.ts`), three lines per handler in the
+constructor, plus the matching `!:` field declarations above it:
+
+```ts
+// x
+x!: (actions: XHandlerHandle) => Be;
+private xHandler!: XHandler;
+someMethod!: XHandler['someMethod'];
+...
+```
+```ts
+this.xHandler = new XHandler(this);
+this.x = this.handle(this.xHandler) as (actions: XHandlerHandle) => Be;
+this.attach(XHandler, 'Suffix');
+```
+
+The `'Suffix'` argument to `attach()` matters whenever a bare method name
+would collide with another handler's (compare `update` / `updateText` /
+`updateHttp` — same verb, three handlers, three suffixes: none, `'Text'`,
+`'Http'`). Pick suffixes for the new handlers below with that in mind —
+`ClassesHandler` (CSS classes: `addClass`/`removeClass`/...) already owns
+the bare name "class", so the OOP class-builder handler in §2.4 cannot be
+named `ClassesHandler` or exposed as `class`/`classes`.
+
+Every handler ships a co-located `x.test.ts` (vitest, `describe`/`it`,
+`document.body.innerHTML = '...'` fixtures — see `events.test.ts`). New
+handlers need the same.
+
+Export new types/handlers from `src/lib/index.ts` alongside the existing
+ones.
+
+---
+
+## 1. `methodize()` breaks the callback-only contract — fix it, not `findAll()`
+
+**File:** `src/lib/modules/walk.ts`, `methodize()` (~line 362), used by
+`up`/`next`/`previous`/`children`/`closest`/`firstChild`/`lastChild`.
+
+idae-be's contract is: results come through `callback`, the return value is
+always the root (`this.beElement`), full stop — that's what `findAll()`
+already does, what every other handler in the package does, and what the
+package's own usage pattern (`.append(content, ({ be }) => be.addClass(...))`)
+demonstrates.
+
+`methodize()` violates it: it returns `resultBe` (the found elements)
+instead of `this.beElement`, which is what lets
+`be('#child').up().addClassName('x')` silently class the parent — jQuery
+chaining, which this library does not otherwise support or want.
+
+**Fix:** `methodize()` returns `this.beElement`, not `resultBe`. The
+`callback` already receives `resultBe` correctly (`be: resultBe` is already
+passed) — that line doesn't change. This brings `up`/`next`/`previous`/
+`children`/`closest`/`firstChild`/`lastChild` in line with `findAll()` and
+every other handler in the package.
+
+Audit call sites (`grep` this package and any consumers) for direct
+chaining off these methods' return value — that usage was always
+inconsistent with the rest of the API and needs migrating to the callback
+form regardless.
+
+---
+
+## 2. Missing capabilities
+
+Each of these is a capability gap against a well-known jQuery/PrototypeJS-
+class feature set — not tied to any particular consumer. Follow §"The
+pattern" above for all of them.
+
+### 2.1 Event delegation — new methods on `EventsHandler` (`events.ts`)
+
+`EventsHandler.on()` only binds directly on the matched element(s). There's
+no delegated form (bind once, fire only when the event's actual target
+matches a descendant selector — standard for handling events on content
+that doesn't exist yet at bind time).
+
+**Add**, in `events.ts`:
+- Overload `on(eventName, handler, options?, callback?)` (existing, direct)
+  **and** `on(eventName, selector, handler, options?, callback?)`
+  (delegated) — detect by whether the 2nd arg is a string. Implementation:
+  bind one real listener per node at the current binding, check
+  `event.target.closest(selector)` is contained in the bound element,
+  invoke `handler` with the matched element (not the bound root).
+- `off(...)` needs the matching overload so a delegated listener can be
+  removed by the same `(eventName, selector, handler)` triple — track
+  delegated bindings (a `WeakMap<Element, Map<string, ...>>` keyed by node)
+  since the *actual* DOM listener is a wrapper closure, not the `handler`
+  the caller passed in.
+
+### 2.2 Form serialization — new `FormHandler` module (`forms.ts`)
+
+No form-specific handler exists: no serialize-to-querystring/object, no
+per-field value accessor that handles checkboxes/radios/multi-selects
+correctly.
+
+**New file** `src/lib/modules/forms.ts`, `FormHandler`, methods:
+- `serialize(options?: { asJSON?: boolean }): string | Record<string, unknown>`
+  — walk `form.elements`, skip disabled/no-name fields, handle
+  checkboxes/radios (only checked ones), `<select multiple>` (array of
+  selected values), return a `URLSearchParams`-style string by default or a
+  plain object when `asJSON`.
+- `getElements(): HTMLElement[]` — `Array.from(form.elements)`.
+- `getValue(): string | string[] | boolean` — value accessor for a single
+  field `Be` wraps; the extraction rule differs by input type
+  (checkbox/radio → checked state, `<select multiple>` → array, everything
+  else → `.value`).
+
+Wire into `Be` as `form!: (actions: FormHandlerHandle) => Be` plus
+`serializeForm!: FormHandler['serialize']`, `fieldValue!:
+FormHandler['getValue']` (suffix/name to avoid collisions — check the full
+field list in `be.ts` before finalizing).
+
+### 2.3 Collection utilities — plain exported functions, not a handler
+
+A small set of collection helpers (array-from-arraylike, whitespace-split
+to array, numeric range, simple key/value map with `.each`) has no
+equivalent. These operate on plain values, not elements — they don't fit
+the `Be`/handler pattern (there's no element for `Be.elem()` to wrap).
+
+**Add**, in `src/lib/utils.ts` or a new `src/lib/collections.ts`:
+- `toArray(iterableOrArrayLike): unknown[]`
+- `toWords(str): string[]` — whitespace-split
+- `range(start, end, exclusive?): number[]`
+- A thin `Hash`-like class with `.get/.set/.each` only if a plain `Map`
+  genuinely isn't enough — default to recommending `Map` over adding a new
+  type.
+
+Export from `src/lib/index.ts` next to `Be`/`be`/`toBe`.
+
+### 2.4 Runtime class builder — standalone module, not a handler
+
+No equivalent of a runtime class-definition helper (build a constructor
+from a spec object, with an `initialize` method and inheritance) or a
+shallow-merge helper for plain objects.
+
+**Recommendation:** standalone module `src/lib/classes-oop.ts` (name it to
+avoid clashing with `modules/classes.ts`, the CSS-class handler), exporting:
+- `createClass(spec: Record<string, Function>, Base?: Function): new (...args) => object`
+  — build an ES class at runtime (`class extends (Base ?? Object) {
+  constructor(...args) { super(); this.initialize?.(...args); } }`, then
+  `Object.assign(X.prototype, spec)`). Consider whether this is worth
+  shipping at all versus documenting that real ES `class` syntax covers the
+  same need directly — flag that tradeoff in the PR.
+- `extendObject(target, source): object` — `Object.assign(target, source)`.
+  One-line re-export, not new logic.
+
+### 2.5 Animation helpers — new `EffectsHandler` (`effects.ts`)
+
+No animation/effects handler exists — no fade/appear/slide/move/scale
+helpers, no drag-and-drop registry.
+
+**New file** `src/lib/modules/effects.ts`, `EffectsHandler`, methods
+`fade`, `appear`, `slideUp`, `slideDown`, `move`, `scale` (adjust the list
+to whatever set is actually worth shipping). Each: build a
+`el.animate(keyframes, options)` call (native Web Animations API — no new
+dependency), resolve/callback on `finish`.
+
+Drag-and-drop: consider whether native `draggable="true"` +
+`dragstart`/`dragend`/`drop` events cover the need before building a
+dedicated drag-registry handler — likely lower priority than the animation
+methods above.
+
+### 2.6 Ajax robustness — extend `HttpHandler` (`http.ts`)
+
+Current `update()`/`insert()` have **no error handling at all** — a
+non-2xx response body is injected as content, and a network failure is an
+unhandled promise rejection (the `fetch()` method on `Be` itself, in
+`be.ts`, has the same gap). No timeout/abort, no query-string helper for
+`GET` params.
+
+**Extend** `HttpHandlerHandle` and `update`/`insert` signatures with:
+- `onFailure?: (response: Response, error?: unknown) => void` callback,
+  invoked instead of the content callback when `!response.ok` or the fetch
+  throws — do not call `beElem.update(errorBody)` in that case.
+- `timeout?: number` — wrap the `fetch` in `AbortController` +
+  `setTimeout(() => controller.abort(), timeout)`.
+- `params?: Record<string, string>` for `GET` — serialize to a query
+  string rather than expecting the caller to have built the URL already.
+
+This is the one change here that touches *existing* public method
+signatures rather than adding new ones — keep the new fields optional so
+current callers (including this package's own `http.test.ts`) don't break.
+
+### 2.7 `getDimensions` / `cumulativeOffset` / `viewportOffset` — extend `PositionHandler` (`position.ts`)
+
+`PositionHandler` already computes `getBoundingClientRect()`-based
+positioning (`clonePosition`, `overlapPosition`, `snapTo`) — these three
+belong here, not a new module.
+
+**Add** to `PositionHandler`:
+- `getDimensions(): { width: number; height: number }` — for elements with
+  `display: none`, measure correctly rather than returning 0×0: make the
+  element temporarily measurable (`position: absolute; visibility: hidden;
+  display: block`), measure, restore.
+- `cumulativeOffset(): { left: number; top: number }` — position relative
+  to the document, accounting for scroll.
+- `viewportOffset(): { left: number; top: number }` — position relative to
+  the viewport (`getBoundingClientRect()` directly, no scroll adjustment).
+
+Add these to `positionMethods` enum and `PositionHandlerHandle`, following
+the exact pattern the three existing methods use.
+
+---
+
+## Priority, if this is split across multiple passes
+
+1. §1 (`methodize()` fix) — one-line change, do it first: every new handler
+   written after this should already follow the corrected contract, not
+   copy the bug into more code.
+2. §2.6 (Ajax error handling) — fixes a real correctness gap in existing
+   code, not just new surface.
+3. §2.1 (event delegation) + §2.7 (dimensions) — broadly useful, standard
+   DOM-library surface.
+4. §2.2 (forms).
+5. §2.3 (collection utilities) + §2.4 (class builder) — mechanical, low
+   risk; consider recommending native `Array`/`class` instead of adding
+   these at all, per the notes in each section.
+6. §2.5 (animation helpers) — most implementation work (timing, easing)
+   for the least certain payoff; do last, or skip in favor of documenting
+   direct Web Animations API / CSS transition usage.

--- a/packages/idae-be/package.json
+++ b/packages/idae-be/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/medyll/idae.git"
   },
-  "version": "1.96.3",
+  "version": "1.97.0",
   "description": "A modern, lightweight, and extensible DOM manipulation library built with TypeScript. Designed for precise element targeting and manipulation using a callback-based approach. Features include advanced DOM traversal, event handling, style management, attribute control, HTTP content loading, timers, and more. Ideal for developers seeking a modular and consistent API for dynamic web applications.",
   "keywords": [
     "idae",

--- a/packages/idae-be/src/lib/be.ts
+++ b/packages/idae-be/src/lib/be.ts
@@ -11,6 +11,8 @@ import { WalkHandler, type WalkHandlerHandle } from './modules/walk.js';
 import { TextHandler, type TextHandlerHandle } from './modules/text.js';
 import { TimersHandler, type TimerHandlerHandle } from './modules/timers.js';
 import { HttpHandler, type HttpHandlerHandle } from './modules/http.js';
+import { FormHandler, type FormHandlerHandle } from './modules/forms.js';
+import { EffectsHandler, type EffectsHandlerHandle } from './modules/effects.js';
 
 export class Be {
 	[key: string]: unknown; // Add an index signature to allow dynamic property assignment
@@ -44,6 +46,9 @@ export class Be {
 	clonePosition!: PositionHandler['clonePosition'];
 	overlapPosition!: PositionHandler['overlapPosition'];
 	snapTo!: PositionHandler['snapTo'];
+	getDimensions!: PositionHandler['getDimensions'];
+	cumulativeOffset!: PositionHandler['cumulativeOffset'];
+	viewportOffset!: PositionHandler['viewportOffset'];
 	// dom
 	dom!: (actions: DomHandlerHandle) => Be;
 	private domHandler!: DomHandler;
@@ -111,6 +116,21 @@ export class Be {
 	private httpHandler!: HttpHandler;
 	updateHttp!: HttpHandler['update'];
 	insertHttp!: HttpHandler['insert'];
+	// forms
+	form!: (actions: FormHandlerHandle) => Be;
+	private formHandler!: FormHandler;
+	serializeForm!: FormHandler['serialize'];
+	fieldValue!: FormHandler['getValue'];
+	getFormElements!: FormHandler['getElements'];
+	// effects
+	effects!: (actions: EffectsHandlerHandle) => Be;
+	private effectsHandler!: EffectsHandler;
+	fade!: EffectsHandler['fade'];
+	appear!: EffectsHandler['appear'];
+	slideUp!: EffectsHandler['slideUp'];
+	slideDown!: EffectsHandler['slideDown'];
+	move!: EffectsHandler['move'];
+	scale!: EffectsHandler['scale'];
 
 	private constructor(input: HTMLElement | HTMLElement[] | Be | string) {
 		if (input instanceof Be) {
@@ -178,6 +198,20 @@ export class Be {
 		this.httpHandler = new HttpHandler(this);
 		this.http = this.handle(this.httpHandler) as (actions: HttpHandlerHandle) => Be;
 		this.attach(HttpHandler, 'Http');
+
+		// forms — wired explicitly (not via attach) so the exposed names are
+		// serializeForm/fieldValue/getFormElements instead of the generic
+		// serialize/getValue, and to avoid any collision with future handlers.
+		this.formHandler = new FormHandler(this);
+		this.form = this.handle(this.formHandler) as (actions: FormHandlerHandle) => Be;
+		this.serializeForm = this.formHandler.serialize.bind(this.formHandler);
+		this.fieldValue = this.formHandler.getValue.bind(this.formHandler);
+		this.getFormElements = this.formHandler.getElements.bind(this.formHandler);
+
+		// effects
+		this.effectsHandler = new EffectsHandler(this);
+		this.effects = this.handle(this.effectsHandler) as (actions: EffectsHandlerHandle) => Be;
+		this.attach(EffectsHandler);
 	}
 
 	/**
@@ -307,12 +341,40 @@ export class Be {
 		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD' | 'CONNECT' | 'TRACE';
 		data?: T;
 		headers?: Record<string, string>;
+		/** Query-string parameters serialized onto the URL. */
+		params?: Record<string, string>;
+		/** Abort the request after this many milliseconds. */
+		timeout?: number;
 	}) {
-		return fetch(options.url, {
+		let url = options.url;
+		if (options.params) {
+			const qs = new URLSearchParams(options.params).toString();
+			if (qs) url += (url.includes('?') ? '&' : '?') + qs;
+		}
+
+		let signal: AbortSignal | undefined;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		if (options.timeout) {
+			const controller = new AbortController();
+			timer = setTimeout(() => controller.abort(), options.timeout);
+			signal = controller.signal;
+		}
+
+		return fetch(url, {
 			method: options.method || 'GET',
 			body: options.data ? JSON.stringify(options.data) : undefined,
-			headers: options.headers || {}
-		}).then((response) => response.json());
+			headers: options.headers || {},
+			signal
+		})
+			.then((response) => {
+				if (!response.ok) {
+					throw new Error(`Be.fetch: request to ${url} failed with status ${response.status}`);
+				}
+				return response.json();
+			})
+			.finally(() => {
+				if (timer) clearTimeout(timer);
+			});
 	}
 
 	/**

--- a/packages/idae-be/src/lib/classes-oop.ts
+++ b/packages/idae-be/src/lib/classes-oop.ts
@@ -1,0 +1,59 @@
+/**
+ * Runtime class-definition helpers (PrototypeJS-style `Class.create`).
+ *
+ * Tradeoff to consider before using `createClass`: native ES `class` syntax
+ * covers the same need directly, with better typing, tooling and performance:
+ *
+ * ```ts
+ * class Animal { constructor(public name: string) {} speak() {} }
+ * class Dog extends Animal { speak() { return 'woof'; } }
+ * ```
+ *
+ * `createClass` is only worth it when the spec object itself is dynamic —
+ * e.g. built at runtime from configuration or migrated legacy code that
+ * composes behavior objects. For static class hierarchies, prefer real
+ * `class` syntax.
+ */
+
+/**
+ * Builds an ES class at runtime from a spec object. If the spec contains an
+ * `initialize` method it acts as the constructor body; `Base` is used as the
+ * superclass when provided.
+ * @param spec - An object of methods to assign on the prototype. A function
+ *   named `initialize` is treated as the constructor.
+ * @param Base - Optional base constructor to extend.
+ * @returns A new constructor.
+ * @example
+ * const Animal = createClass({
+ *   initialize(name: string) { this.name = name; },
+ *   speak() { return `${this.name} makes a sound`; }
+ * });
+ * const Dog = createClass({ speak() { return 'woof'; } }, Animal);
+ * new (Dog as any)('rex').speak(); // 'woof'
+ */
+export function createClass(
+	spec: Record<string, Function>,
+	Base?: new (...args: unknown[]) => unknown
+): new (...args: unknown[]) => object {
+	const Parent = Base ?? Object;
+
+	const Klass = class extends (Parent as new (...args: unknown[]) => object) {
+		constructor(...args: unknown[]) {
+			super(...args);
+			(spec.initialize as ((...a: unknown[]) => void) | undefined)?.apply(this, args);
+		}
+	};
+
+	Object.assign(Klass.prototype, spec);
+
+	return Klass as new (...args: unknown[]) => object;
+}
+
+/**
+ * Shallow-merges `source` into `target` and returns `target`.
+ * A one-line re-export of `Object.assign` semantics, kept for API parity —
+ * prefer `Object.assign` (or object spread) directly in new code.
+ */
+export function extendObject<T extends object, S extends object>(target: T, source: S): T & S {
+	return Object.assign(target, source);
+}

--- a/packages/idae-be/src/lib/collections.test.ts
+++ b/packages/idae-be/src/lib/collections.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { toArray, toWords, range } from './collections.js';
+import { createClass, extendObject } from './classes-oop.js';
+
+describe('collections', () => {
+	it('toArray converts array-like and iterable values', () => {
+		expect(toArray('abc')).toEqual(['a', 'b', 'c']);
+		expect(toArray(new Set([1, 2]))).toEqual([1, 2]);
+
+		const arrayLike = { 0: 'x', 1: 'y', length: 2 };
+		expect(toArray(arrayLike as unknown as ArrayLike<string>)).toEqual(['x', 'y']);
+	});
+
+	it('toArray handles DOM array-likes', () => {
+		document.body.innerHTML = '<span></span><span></span>';
+		expect(toArray(document.querySelectorAll('span'))).toHaveLength(2);
+	});
+
+	it('toWords splits on whitespace and drops empties', () => {
+		expect(toWords('  alpha  beta\tgamma\n delta ')).toEqual(['alpha', 'beta', 'gamma', 'delta']);
+		expect(toWords('')).toEqual([]);
+	});
+
+	it('range builds inclusive ranges by default', () => {
+		expect(range(1, 4)).toEqual([1, 2, 3, 4]);
+		expect(range(0, 0)).toEqual([0]);
+	});
+
+	it('range supports exclusive end and descending order', () => {
+		expect(range(1, 4, true)).toEqual([1, 2, 3]);
+		expect(range(3, 1)).toEqual([3, 2, 1]);
+		expect(range(3, 1, true)).toEqual([3, 2]);
+	});
+});
+
+describe('classes-oop', () => {
+	it('createClass builds a constructor with initialize', () => {
+		const Animal = createClass({
+			initialize(this: Record<string, unknown>, name: string) {
+				this.name = name;
+			},
+			speak(this: Record<string, unknown>) {
+				return `${this.name} makes a sound`;
+			}
+		});
+
+		const a = new (Animal as new (name: string) => { speak(): string })('rex');
+		expect(a.speak()).toBe('rex makes a sound');
+	});
+
+	it('createClass supports inheritance with spec override', () => {
+		const Animal = createClass({
+			initialize(this: Record<string, unknown>, name: string) {
+				this.name = name;
+			},
+			speak() {
+				return 'generic';
+			}
+		});
+		const Dog = createClass(
+			{
+				speak() {
+					return 'woof';
+				}
+			},
+			Animal
+		);
+
+		const d = new (Dog as new (name: string) => { name: string; speak(): string })('rex');
+		expect(d.speak()).toBe('woof');
+		expect(d.name).toBe('rex');
+		expect(d instanceof (Animal as unknown as new () => object)).toBe(true);
+	});
+
+	it('extendObject shallow-merges source into target', () => {
+		const target = { a: 1, b: 2 };
+		const result = extendObject(target, { b: 3, c: 4 });
+
+		expect(result).toEqual({ a: 1, b: 3, c: 4 });
+		expect(result).toBe(target);
+	});
+});

--- a/packages/idae-be/src/lib/collections.ts
+++ b/packages/idae-be/src/lib/collections.ts
@@ -1,0 +1,58 @@
+/**
+ * Collection utilities operating on plain values (not DOM elements), so they
+ * intentionally do NOT follow the `Be`/handler pattern.
+ *
+ * Note: for a key/value store, prefer the native `Map` — it already provides
+ * `.get`/`.set`/`.forEach` and iteration. No `Hash`-like class is shipped here.
+ */
+
+/**
+ * Converts an iterable or array-like value to a real array.
+ * @param input - The iterable or array-like value to convert.
+ * @returns A new array containing the input's items.
+ * @example
+ * toArray(document.querySelectorAll('div')); // HTMLElement[]
+ * toArray('abc'); // ['a', 'b', 'c']
+ */
+export function toArray<T = unknown>(input: Iterable<T> | ArrayLike<T>): T[] {
+	if (input == null) return [];
+	if (typeof (input as Iterable<T>)[Symbol.iterator] === 'function') {
+		return Array.from(input as Iterable<T>);
+	}
+	return Array.prototype.slice.call(input) as T[];
+}
+
+/**
+ * Splits a string on whitespace into an array of words.
+ * @param str - The string to split.
+ * @returns The non-empty whitespace-separated tokens.
+ * @example
+ * toWords('  alpha  beta\tgamma '); // ['alpha', 'beta', 'gamma']
+ */
+export function toWords(str: string): string[] {
+	return str.trim().split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Builds a numeric range from `start` (inclusive) to `end`.
+ * By default `end` is inclusive; pass `exclusive: true` to exclude it.
+ * Descending ranges are supported when `start > end`.
+ * @param start - The first value of the range.
+ * @param end - The boundary value of the range.
+ * @param exclusive - When true, `end` is excluded.
+ * @returns The array of integers in the range.
+ * @example
+ * range(1, 4); // [1, 2, 3, 4]
+ * range(1, 4, true); // [1, 2, 3]
+ * range(3, 1); // [3, 2, 1]
+ */
+export function range(start: number, end: number, exclusive = false): number[] {
+	const result: number[] = [];
+	const step = start <= end ? 1 : -1;
+	const stop = exclusive ? end : end + step;
+
+	for (let i = start; i !== stop; i += step) {
+		result.push(i);
+	}
+	return result;
+}

--- a/packages/idae-be/src/lib/dic/proxyHandler.ts
+++ b/packages/idae-be/src/lib/dic/proxyHandler.ts
@@ -35,16 +35,20 @@ export class DynamicHandler {
 					const cssValue = subProp.toLowerCase();
 					return () => {
 						this.beElement.eachNode((el: HTMLElement) => {
-							(el[this.attr] as any)[cssProp] = cssValue;
+							(el as unknown as Record<string, Record<string, string>>)[this.attr][cssProp] =
+								cssValue;
 						});
 					};
 				} else {
 					return (value?: string) => {
 						this.beElement.eachNode((el: HTMLElement) => {
+							const styleTarget = (el as unknown as Record<string, Record<string, string>>)[
+								this.attr
+							];
 							if (value === undefined) {
-								(el[this.attr] as any)[cssProp] = '';
+								styleTarget[cssProp] = '';
 							} else {
-								(el[this.attr] as any)[cssProp] = value;
+								styleTarget[cssProp] = value;
 							}
 						});
 					};

--- a/packages/idae-be/src/lib/index.ts
+++ b/packages/idae-be/src/lib/index.ts
@@ -1,12 +1,16 @@
 // auto exports of entry components
 export * from '$lib/be.js';
+export * from '$lib/classes-oop.js';
+export * from '$lib/collections.js';
 export * from '$lib/dic/fragment.js';
 export * from '$lib/dic/proxyHandler.js';
 export * from '$lib/modules/attrs.js';
 export * from '$lib/modules/classes.js';
 export * from '$lib/modules/data.js';
 export * from '$lib/modules/dom.js';
+export * from '$lib/modules/effects.js';
 export * from '$lib/modules/events.js';
+export * from '$lib/modules/forms.js';
 export * from '$lib/modules/http.js';
 export * from '$lib/modules/position.js';
 export * from '$lib/modules/styles.js';

--- a/packages/idae-be/src/lib/modules/data.ts
+++ b/packages/idae-be/src/lib/modules/data.ts
@@ -22,7 +22,7 @@ export type DataHandlerHandle = {
 /**
  * Handles operations on `data-*` attributes for Be elements.
  */
-export class DataHandler implements CommonHandler<DataHandler> {
+export class DataHandler implements CommonHandler<DataHandler, Partial<DataHandlerHandle>> {
 	private beElement: Be;
 	static methods = Object.values(dataMethods);
 
@@ -41,10 +41,7 @@ export class DataHandler implements CommonHandler<DataHandler> {
 	 * @returns The Be element for chaining.
 	 */
 	handle(actions: Partial<DataHandlerHandle>): Be {
-		const { method, props } = BeUtils.resolveIndirection<DataHandler>(
-			this,
-			actions as unknown as keyof DataHandler
-		);
+		const { method, props } = BeUtils.resolveIndirection<DataHandler>(this, actions);
 		switch (method) {
 			case 'set':
 			case 'delete':
@@ -131,7 +128,12 @@ export class DataHandler implements CommonHandler<DataHandler> {
 	 */
 	getKey(key: string | string[]): string | null {
 		if (this.beElement.isWhat !== 'element') return null;
-		return (this.beElement.inputNode as HTMLElement).dataset[key] || null;
+		const keys = Array.isArray(key) ? key : [key];
+		for (const k of keys) {
+			const value = (this.beElement.inputNode as HTMLElement).dataset[k];
+			if (value !== undefined) return value;
+		}
+		return null;
 	}
 
 	/**

--- a/packages/idae-be/src/lib/modules/effects.test.ts
+++ b/packages/idae-be/src/lib/modules/effects.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { be } from '../be.js';
+
+describe('EffectsHandler', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="test">content</div>';
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should be wired on Be', () => {
+		const instance = be('#test');
+		for (const method of ['effects', 'fade', 'appear', 'slideUp', 'slideDown', 'move', 'scale']) {
+			expect(typeof instance[method as keyof typeof instance]).toBe('function');
+		}
+	});
+
+	it('fade applies the final state synchronously when animate is unavailable', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		expect(typeof el.animate).not.toBe('function'); // jsdom
+
+		const callback = vi.fn();
+		const root = be('#test').fade(undefined, callback);
+
+		expect(el.style.opacity).toBe('0');
+		expect(el.style.display).toBe('none');
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(root.node).toBe(el); // returns the root
+	});
+
+	it('appear restores opacity from hidden', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		el.style.display = 'none';
+
+		be('#test').appear();
+
+		expect(el.style.opacity).toBe('1');
+		expect(el.style.display).toBe('');
+	});
+
+	it('slideUp hides the element', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		be('#test').slideUp();
+		expect(el.style.display).toBe('none');
+	});
+
+	it('slideDown keeps the element visible', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		el.style.display = 'none';
+		be('#test').slideDown();
+		expect(el.style.display).toBe('');
+	});
+
+	it('move applies the translation as final style', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		be('#test').move({ x: 10, y: 20 });
+		expect(el.style.transform).toBe('translate(10px, 20px)');
+	});
+
+	it('scale applies the target scale as final style', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		be('#test').scale({ from: 0.5, to: 2 });
+		expect(el.style.transform).toBe('scale(2)');
+	});
+
+	it('uses el.animate and defers the callback to onfinish when available', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		let onfinish: (() => void) | undefined;
+		const animateMock = vi.fn().mockReturnValue({
+			set onfinish(fn: () => void) {
+				onfinish = fn;
+			}
+		});
+		Object.defineProperty(el, 'animate', { configurable: true, value: animateMock });
+
+		const callback = vi.fn();
+		be('#test').fade({ duration: 250, easing: 'linear' }, callback);
+
+		expect(animateMock).toHaveBeenCalledWith(
+			[{ opacity: 1 }, { opacity: 0 }],
+			expect.objectContaining({ duration: 250, easing: 'linear', fill: 'forwards' })
+		);
+		expect(callback).not.toHaveBeenCalled();
+
+		onfinish?.();
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(el.style.opacity).toBe('0');
+		expect(el.style.display).toBe('none');
+	});
+
+	it('works through the effects() handle dispatch', () => {
+		const el = document.getElementById('test') as HTMLElement;
+		be('#test').effects({
+			move: { options: { x: 5, y: 5 } },
+			scale: { options: { to: 1.5 } }
+		});
+		// last applied transform wins (scale ran after move)
+		expect(el.style.transform).toBe('scale(1.5)');
+	});
+});

--- a/packages/idae-be/src/lib/modules/effects.ts
+++ b/packages/idae-be/src/lib/modules/effects.ts
@@ -1,0 +1,253 @@
+import { Be, be } from '../be.js';
+import type { CommonHandler, HandlerCallBackFn } from '../types.js';
+
+enum effectsMethods {
+	fade = 'fade',
+	appear = 'appear',
+	slideUp = 'slideUp',
+	slideDown = 'slideDown',
+	move = 'move',
+	scale = 'scale'
+}
+
+export interface EffectOptions {
+	/** Animation duration in milliseconds. Default 400. */
+	duration?: number;
+	/** CSS easing function. Default 'ease'. */
+	easing?: string;
+	/** Delay before the animation starts, in milliseconds. */
+	delay?: number;
+}
+
+export interface MoveOptions extends EffectOptions {
+	/** Horizontal translation in px (added to the current position). Default 0. */
+	x?: number;
+	/** Vertical translation in px (added to the current position). Default 0. */
+	y?: number;
+}
+
+export interface ScaleOptions extends EffectOptions {
+	/** Starting scale factor. Default 1. */
+	from?: number;
+	/** Target scale factor. Default 1. */
+	to?: number;
+}
+
+export interface EffectsHandlerHandle {
+	fade?: { options?: EffectOptions; callback?: HandlerCallBackFn };
+	appear?: { options?: EffectOptions; callback?: HandlerCallBackFn };
+	slideUp?: { options?: EffectOptions; callback?: HandlerCallBackFn };
+	slideDown?: { options?: EffectOptions; callback?: HandlerCallBackFn };
+	move?: { options?: MoveOptions; callback?: HandlerCallBackFn };
+	scale?: { options?: ScaleOptions; callback?: HandlerCallBackFn };
+}
+
+type KeyframeSpec = {
+	keyframes: Keyframe[];
+	/** Inline styles to apply when the animation finishes (final state). */
+	finalStyles: Record<string, string>;
+};
+
+/**
+ * Animation helpers built on the native Web Animations API — no dependency.
+ * When `el.animate` is unavailable (e.g. jsdom), the final state is applied
+ * synchronously and the callback fires immediately.
+ */
+export class EffectsHandler implements CommonHandler<EffectsHandler, EffectsHandlerHandle> {
+	private beElement: Be;
+
+	static methods = Object.values(effectsMethods);
+
+	constructor(beElement: Be) {
+		this.beElement = beElement;
+	}
+
+	methods: string[] = EffectsHandler.methods;
+
+	/**
+	 * Handles effect actions.
+	 * @param actions - The actions to perform.
+	 * @returns The Be instance (root) for method chaining.
+	 */
+	handle(actions: EffectsHandlerHandle): Be {
+		Object.entries(actions).forEach(([method, props]) => {
+			switch (method) {
+				case 'fade':
+				case 'appear':
+				case 'slideUp':
+				case 'slideDown':
+					this[method](props.options, props.callback);
+					break;
+				case 'move':
+				case 'scale':
+					this[method](props.options as never, props.callback);
+					break;
+			}
+		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Fades the element(s) to transparent, then hides them (`display: none`).
+	 * @param options - Duration/easing/delay options.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	fade(options?: EffectOptions, callback?: HandlerCallBackFn): Be {
+		return this.play(
+			() => ({
+				keyframes: [{ opacity: 1 }, { opacity: 0 }],
+				finalStyles: { opacity: '0', display: 'none' }
+			}),
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Fades the element(s) in from transparent.
+	 * @param options - Duration/easing/delay options.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	appear(options?: EffectOptions, callback?: HandlerCallBackFn): Be {
+		return this.play(
+			(el) => {
+				if (window.getComputedStyle(el).display === 'none') {
+					el.style.display = '';
+					el.style.opacity = '0';
+				}
+				return {
+					keyframes: [{ opacity: 0 }, { opacity: 1 }],
+					finalStyles: { opacity: '1' }
+				};
+			},
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Collapses the element(s) vertically, then hides them (`display: none`).
+	 * @param options - Duration/easing/delay options.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	slideUp(options?: EffectOptions, callback?: HandlerCallBackFn): Be {
+		return this.play(
+			(el) => {
+				const height = el.offsetHeight;
+				return {
+					keyframes: [
+						{ height: `${height}px`, overflow: 'hidden' },
+						{ height: '0px', overflow: 'hidden' }
+					],
+					finalStyles: { display: 'none', height: '' }
+				};
+			},
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Expands the element(s) vertically from hidden.
+	 * @param options - Duration/easing/delay options.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	slideDown(options?: EffectOptions, callback?: HandlerCallBackFn): Be {
+		return this.play(
+			(el) => {
+				const wasHidden = window.getComputedStyle(el).display === 'none';
+				if (wasHidden) el.style.display = '';
+				const height = el.offsetHeight;
+				return {
+					keyframes: [
+						{ height: '0px', overflow: 'hidden' },
+						{ height: `${height}px`, overflow: 'hidden' }
+					],
+					finalStyles: { height: '' }
+				};
+			},
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Translates the element(s) by the given offset, leaving the translation applied.
+	 * @param options - `{ x, y }` offsets in px plus duration/easing/delay.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	move(options?: MoveOptions, callback?: HandlerCallBackFn): Be {
+		const { x = 0, y = 0 } = options ?? {};
+		return this.play(
+			() => ({
+				keyframes: [{ transform: 'translate(0px, 0px)' }, { transform: `translate(${x}px, ${y}px)` }],
+				finalStyles: { transform: `translate(${x}px, ${y}px)` }
+			}),
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Scales the element(s) from `from` to `to`, leaving the transform applied.
+	 * @param options - `{ from, to }` scale factors plus duration/easing/delay.
+	 * @param callback - Optional callback fired when the animation finishes, per node.
+	 * @returns The Be instance (root).
+	 */
+	scale(options?: ScaleOptions, callback?: HandlerCallBackFn): Be {
+		const { from = 1, to = 1 } = options ?? {};
+		return this.play(
+			() => ({
+				keyframes: [{ transform: `scale(${from})` }, { transform: `scale(${to})` }],
+				finalStyles: { transform: `scale(${to})` }
+			}),
+			options,
+			callback
+		);
+	}
+
+	/**
+	 * Runs an animation on every wrapped node and fires the callback on finish.
+	 * Falls back to applying the final styles synchronously when the Web
+	 * Animations API is unavailable.
+	 */
+	private play(
+		spec: (el: HTMLElement) => KeyframeSpec,
+		options: EffectOptions | undefined,
+		callback?: HandlerCallBackFn
+	): Be {
+		const { duration = 400, easing = 'ease', delay = 0 } = options ?? {};
+
+		this.beElement.eachNode((el) => {
+			const { keyframes, finalStyles } = spec(el);
+
+			const finish = () => {
+				Object.assign(el.style, finalStyles);
+				callback?.({
+					fragment: undefined,
+					be: be(el),
+					root: this.beElement
+				});
+			};
+
+			if (typeof el.animate === 'function') {
+				const animation = el.animate(keyframes, { duration, easing, delay, fill: 'forwards' });
+				animation.onfinish = finish;
+			} else {
+				finish();
+			}
+		});
+
+		return this.beElement;
+	}
+
+	valueOf(): Be {
+		return this.beElement;
+	}
+}

--- a/packages/idae-be/src/lib/modules/events.test.ts
+++ b/packages/idae-be/src/lib/modules/events.test.ts
@@ -99,4 +99,68 @@ describe('EventsHandler', () => {
 		expect(mockHandler1).not.toHaveBeenCalled();
 		expect(mockHandler2).not.toHaveBeenCalled();
 	});
+
+	describe('event delegation', () => {
+		beforeEach(() => {
+			document.body.innerHTML = `
+				<div id="root">
+					<button class="item" id="btn1">one</button>
+					<span class="other" id="span1">other</span>
+				</div>
+			`;
+		});
+
+		it('should fire delegated handler only when the target matches the selector', () => {
+			const mockHandler = vi.fn();
+			be('#root').on('click', '.item', mockHandler);
+
+			document.querySelector('#btn1')?.dispatchEvent(new Event('click', { bubbles: true }));
+			document.querySelector('#span1')?.dispatchEvent(new Event('click', { bubbles: true }));
+
+			expect(mockHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('should invoke delegated handler with the matched element, not the bound root', () => {
+			let receivedThis: unknown = null;
+			const handler = function (this: unknown) {
+				receivedThis = this;
+			} as EventListener;
+
+			be('#root').on('click', '.item', handler);
+			document.querySelector('#btn1')?.dispatchEvent(new Event('click', { bubbles: true }));
+
+			expect(receivedThis).toBe(document.querySelector('#btn1'));
+		});
+
+		it('should fire for descendants of the matched element', () => {
+			document.body.innerHTML = `
+				<div id="root">
+					<div class="item" id="outer"><span id="inner">inner</span></div>
+				</div>
+			`;
+			const mockHandler = vi.fn();
+			be('#root').on('click', '.item', mockHandler);
+
+			document.querySelector('#inner')?.dispatchEvent(new Event('click', { bubbles: true }));
+			expect(mockHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('should remove a delegated listener with the same (eventName, selector, handler) triple', () => {
+			const mockHandler = vi.fn();
+			be('#root').on('click', '.item', mockHandler);
+			be('#root').off('click', '.item', mockHandler);
+
+			document.querySelector('#btn1')?.dispatchEvent(new Event('click', { bubbles: true }));
+			expect(mockHandler).not.toHaveBeenCalled();
+		});
+
+		it('should not fire after off even when a different Be instance wraps the element', () => {
+			const mockHandler = vi.fn();
+			be(document.querySelector('#root') as HTMLElement).on('click', '.item', mockHandler);
+			be('#root').off('click', '.item', mockHandler);
+
+			document.querySelector('#btn1')?.dispatchEvent(new Event('click', { bubbles: true }));
+			expect(mockHandler).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/idae-be/src/lib/modules/events.ts
+++ b/packages/idae-be/src/lib/modules/events.ts
@@ -55,22 +55,76 @@ export class EventsHandler implements CommonHandler<EventsHandler, EventHandlerH
 
 	/**
 	 * Adds an event listener to the element(s).
+	 *
+	 * Two forms are supported:
+	 * - Direct: `on(eventName, handler, options?, callback?)` — binds on the matched element(s).
+	 * - Delegated: `on(eventName, selector, handler, options?, callback?)` — binds one
+	 *   listener per matched element, but only invokes `handler` when the event's actual
+	 *   target matches a descendant of the bound element that fits `selector`. `handler`
+	 *   is invoked with `this` set to the matched descendant (not the bound root).
+	 *
 	 * @param eventName - The name of the event to listen for.
-	 * @param handler - The event handler function.
-	 * @param options - Optional event listener options.
+	 * @param selectorOrHandler - A descendant selector (delegated form) or the event handler.
+	 * @param handlerOrOptions - The event handler (delegated form) or listener options.
+	 * @param optionsOrCallback - Listener options or the callback function.
 	 * @param callback - Optional callback function to execute after adding the event listener.
 	 * @returns The Be instance for method chaining.
 	 * @example
 	 * // HTML: <div id="test"></div>
 	 * const beInstance = be('#test');
 	 * beInstance.on('click', () => console.log('Clicked!')); // Adds a click event listener
+	 *
+	 * // Delegated: fires only when a '.item' descendant is clicked
+	 * beInstance.on('click', '.item', function (e) { console.log(this); });
 	 */
 	on(
 		eventName: string,
-		handler: EventListener,
-		options?: boolean | AddEventListenerOptions,
+		selectorOrHandler: string | EventListener,
+		handlerOrOptions?: EventListener | boolean | AddEventListenerOptions,
+		optionsOrCallback?: boolean | AddEventListenerOptions | HandlerCallBackFn,
 		callback?: HandlerCallBackFn
 	) {
+		if (typeof selectorOrHandler === 'string') {
+			const selector = selectorOrHandler;
+			const handler = handlerOrOptions as EventListener;
+			let options: boolean | AddEventListenerOptions | undefined;
+			if (typeof optionsOrCallback === 'function') {
+				callback = optionsOrCallback;
+			} else {
+				options = optionsOrCallback;
+			}
+
+			this.beElement.eachNode((el) => {
+				const wrapper: EventListener = (event) => {
+					const target = event.target as Element | null;
+					const matched = target?.closest?.(selector);
+					if (matched && matched !== el && el.contains(matched)) {
+						handler.call(matched, event);
+					}
+				};
+				this.trackDelegated(el, eventName, selector, handler, wrapper);
+				el.addEventListener(eventName, wrapper, options);
+				callback?.({
+					fragment: undefined,
+					be: be(el),
+					root: this.beElement
+				});
+			});
+			return this.beElement;
+		}
+
+		const handler = selectorOrHandler;
+		let options: boolean | AddEventListenerOptions | undefined;
+		if (typeof handlerOrOptions === 'function') {
+			// on(eventName, handler, callback)
+			callback = handlerOrOptions as unknown as HandlerCallBackFn;
+		} else {
+			options = handlerOrOptions as boolean | AddEventListenerOptions | undefined;
+			if (typeof optionsOrCallback === 'function') {
+				callback = optionsOrCallback;
+			}
+		}
+
 		this.beElement.eachNode((el) => {
 			el.addEventListener(eventName, handler, options);
 			callback?.({
@@ -84,24 +138,56 @@ export class EventsHandler implements CommonHandler<EventsHandler, EventHandlerH
 
 	/**
 	 * Removes an event listener from the element(s).
-	 * @param eventName - The name of the event to remove.
-	 * @param handler - The event handler function.
-	 * @param options - Optional event listener options.
-	 * @param callback - Optional callback function to execute after removing the event listener.
-	 * @returns The Be instance for method chaining.
-	 * @example
-	 * // HTML: <div id="test"></div>
-	 * const beInstance = be('#test');
-	 * const handler = () => console.log('Clicked!');
-	 * beInstance.on('click', handler); // Adds a click event listener
-	 * beInstance.off('click', handler); // Removes the click event listener
+	 *
+	 * Two forms are supported:
+	 * - Direct: `off(eventName, handler, options?, callback?)`
+	 * - Delegated: `off(eventName, selector, handler, options?, callback?)` — removes a
+	 *   delegated listener previously registered with the same `(eventName, selector, handler)`
+	 *   triple.
 	 */
 	off(
 		eventName: string,
-		handler: EventListener,
-		options?: boolean | AddEventListenerOptions,
+		selectorOrHandler: string | EventListener,
+		handlerOrOptions?: EventListener | boolean | AddEventListenerOptions,
+		optionsOrCallback?: boolean | AddEventListenerOptions | HandlerCallBackFn,
 		callback?: HandlerCallBackFn
 	) {
+		if (typeof selectorOrHandler === 'string') {
+			const selector = selectorOrHandler;
+			const handler = handlerOrOptions as EventListener;
+			let options: boolean | AddEventListenerOptions | undefined;
+			if (typeof optionsOrCallback === 'function') {
+				callback = optionsOrCallback;
+			} else {
+				options = optionsOrCallback;
+			}
+
+			this.beElement.eachNode((el) => {
+				const wrapper = this.delegatedFor(el, eventName, selector, handler);
+				if (wrapper) {
+					el.removeEventListener(eventName, wrapper, options);
+					this.untrackDelegated(el, eventName, selector, handler);
+				}
+				callback?.({
+					fragment: undefined,
+					be: be(el),
+					root: this.beElement
+				});
+			});
+			return this.beElement;
+		}
+
+		const handler = selectorOrHandler;
+		let options: boolean | AddEventListenerOptions | undefined;
+		if (typeof handlerOrOptions === 'function') {
+			callback = handlerOrOptions as unknown as HandlerCallBackFn;
+		} else {
+			options = handlerOrOptions as boolean | AddEventListenerOptions | undefined;
+			if (typeof optionsOrCallback === 'function') {
+				callback = optionsOrCallback;
+			}
+		}
+
 		this.beElement.eachNode((el) => {
 			el.removeEventListener(eventName, handler, options);
 			callback?.({
@@ -112,6 +198,64 @@ export class EventsHandler implements CommonHandler<EventsHandler, EventHandlerH
 		});
 
 		return this.beElement;
+	}
+
+	/**
+	 * Delegated listeners registry: the actual DOM listener is a wrapper closure,
+	 * so we keep a (handler -> wrapper) map per element/event/selector triple
+	 * to be able to remove it later.
+	 */
+	private static delegated = new WeakMap<Element, Map<string, Map<EventListener, EventListener>>>();
+
+	private static delegatedKey(eventName: string, selector: string): string {
+		return `${eventName}::${selector}`;
+	}
+
+	private trackDelegated(
+		el: Element,
+		eventName: string,
+		selector: string,
+		handler: EventListener,
+		wrapper: EventListener
+	): void {
+		let perEl = EventsHandler.delegated.get(el);
+		if (!perEl) {
+			perEl = new Map();
+			EventsHandler.delegated.set(el, perEl);
+		}
+		const key = EventsHandler.delegatedKey(eventName, selector);
+		let perKey = perEl.get(key);
+		if (!perKey) {
+			perKey = new Map();
+			perEl.set(key, perKey);
+		}
+		perKey.set(handler, wrapper);
+	}
+
+	private delegatedFor(
+		el: Element,
+		eventName: string,
+		selector: string,
+		handler: EventListener
+	): EventListener | undefined {
+		return EventsHandler.delegated
+			.get(el)
+			?.get(EventsHandler.delegatedKey(eventName, selector))
+			?.get(handler);
+	}
+
+	private untrackDelegated(
+		el: Element,
+		eventName: string,
+		selector: string,
+		handler: EventListener
+	): void {
+		const perEl = EventsHandler.delegated.get(el);
+		const key = EventsHandler.delegatedKey(eventName, selector);
+		const perKey = perEl?.get(key);
+		perKey?.delete(handler);
+		if (perKey && perKey.size === 0) perEl?.delete(key);
+		if (perEl && perEl.size === 0) EventsHandler.delegated.delete(el);
 	}
 
 	/**

--- a/packages/idae-be/src/lib/modules/forms.test.ts
+++ b/packages/idae-be/src/lib/modules/forms.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { be } from '../be.js';
+
+describe('FormHandler', () => {
+	beforeEach(() => {
+		document.body.innerHTML = `
+			<form id="form">
+				<input type="text" name="name" value="john" />
+				<input type="text" name="skipped" value="no-name-attr-ok" />
+				<input type="text" value="no-name" />
+				<input type="text" name="disabledField" value="off" disabled />
+				<input type="checkbox" name="agree" value="yes" checked />
+				<input type="checkbox" name="newsletter" value="yes" />
+				<input type="radio" name="color" value="red" checked />
+				<input type="radio" name="color" value="blue" />
+				<select name="tags" multiple>
+					<option value="a" selected>a</option>
+					<option value="b" selected>b</option>
+					<option value="c">c</option>
+				</select>
+				<textarea name="bio">hello</textarea>
+			</form>
+			<input type="checkbox" id="lone" checked />
+			<select id="multi" multiple>
+				<option value="x" selected>x</option>
+				<option value="y" selected>y</option>
+			</select>
+		`;
+	});
+
+	it('should be wired on Be', () => {
+		const instance = be('#form');
+		expect(typeof instance.form).toBe('function');
+		expect(typeof instance.serializeForm).toBe('function');
+		expect(typeof instance.fieldValue).toBe('function');
+		expect(typeof instance.getFormElements).toBe('function');
+	});
+
+	it('should serialize to a query string by default', () => {
+		const result = be('#form').serializeForm() as string;
+		const params = new URLSearchParams(result);
+
+		expect(params.get('name')).toBe('john');
+		expect(params.get('agree')).toBe('yes');
+		expect(params.get('color')).toBe('red');
+		expect(params.getAll('tags')).toEqual(['a', 'b']);
+		expect(params.get('bio')).toBe('hello');
+	});
+
+	it('should skip disabled, nameless, unchecked and non-submittable fields', () => {
+		const result = be('#form').serializeForm() as string;
+		const params = new URLSearchParams(result);
+
+		expect(params.has('disabledField')).toBe(false);
+		expect(params.has('newsletter')).toBe(false);
+		expect(params.getAll('color')).toEqual(['red']);
+		// nameless input never appears
+		expect([...params.values()]).not.toContain('no-name');
+	});
+
+	it('should serialize to a plain object with asJSON', () => {
+		const result = be('#form').serializeForm({ asJSON: true }) as Record<string, unknown>;
+
+		expect(result.name).toBe('john');
+		expect(result.tags).toEqual(['a', 'b']);
+		expect(result.color).toBe('red');
+		expect(result.disabledField).toBeUndefined();
+	});
+
+	it('should pass the serialized value through the callback fragment', () => {
+		be('#form').serializeForm(undefined, ({ fragment }) => {
+			expect(typeof fragment).toBe('string');
+			expect(fragment).toContain('name=john');
+		});
+	});
+
+	it('should return the form elements via getFormElements', () => {
+		const elements = be('#form').getFormElements();
+		expect(elements.length).toBe(10);
+		expect(elements.every((el) => el instanceof HTMLElement)).toBe(true);
+	});
+
+	it('should extract values per field type via fieldValue', () => {
+		expect(be('#lone').fieldValue()).toBe(true);
+		expect(be('#multi').fieldValue()).toEqual(['x', 'y']);
+
+		const nameInput = document.querySelector('input[name="name"]') as HTMLElement;
+		expect(be(nameInput).fieldValue()).toBe('john');
+	});
+
+	it('should work through the form() handle dispatch', () => {
+		let serialized: unknown;
+		be('#form').form({
+			serialize: {
+				options: { asJSON: true },
+				callback: ({ fragment }) => {
+					serialized = fragment;
+				}
+			}
+		});
+		expect((serialized as Record<string, unknown>).name).toBe('john');
+	});
+});

--- a/packages/idae-be/src/lib/modules/forms.ts
+++ b/packages/idae-be/src/lib/modules/forms.ts
@@ -1,0 +1,218 @@
+import { Be } from '../be.js';
+import type { CommonHandler, HandlerCallBackFn } from '../types.js';
+
+enum formMethods {
+	serialize = 'serialize',
+	getElements = 'getElements',
+	getValue = 'getValue'
+}
+
+export interface FormSerializeOptions {
+	/** Return a plain object instead of a URL-encoded query string. */
+	asJSON?: boolean;
+}
+
+export interface FormHandlerHandle {
+	serialize?: { options?: FormSerializeOptions; callback?: HandlerCallBackFn };
+	getElements?: { callback?: HandlerCallBackFn };
+	getValue?: { callback?: HandlerCallBackFn };
+}
+
+export type FormFieldValue = string | string[] | boolean;
+
+/**
+ * Handles form operations for Be elements: serialization, element access and
+ * per-field value extraction.
+ */
+export class FormHandler implements CommonHandler<FormHandler, FormHandlerHandle> {
+	private beElement: Be;
+
+	static methods = Object.values(formMethods);
+
+	constructor(beElement: Be) {
+		this.beElement = beElement;
+	}
+
+	methods: string[] = FormHandler.methods;
+
+	/**
+	 * Handles form actions.
+	 * @param actions - The actions to perform.
+	 * @returns The Be instance (root) for method chaining.
+	 */
+	handle(actions: FormHandlerHandle): Be {
+		Object.entries(actions).forEach(([method, props]) => {
+			switch (method) {
+				case 'serialize':
+					this.serialize(props.options, props.callback);
+					break;
+				case 'getElements':
+					this.getElements(props.callback);
+					break;
+				case 'getValue':
+					this.getValue(props.callback);
+					break;
+			}
+		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Serializes the form's fields. Disabled and nameless fields are skipped;
+	 * only checked checkboxes/radios are included; `<select multiple>` produces
+	 * repeated entries (query string) or an array of values (asJSON).
+	 * @param options - Optional `{ asJSON }` flag.
+	 * @param callback - Optional callback receiving the serialized value as `fragment`.
+	 * @returns A URL-encoded string by default, a plain object when `asJSON`.
+	 * @example
+	 * be('#myForm').serializeForm(); // "name=john&tags=a&tags=b"
+	 * be('#myForm').serializeForm({ asJSON: true }); // { name: 'john', tags: ['a', 'b'] }
+	 */
+	serialize(
+		options?: FormSerializeOptions,
+		callback?: HandlerCallBackFn
+	): string | Record<string, unknown> {
+		const fields = this.collectFields();
+
+		let result: string | Record<string, unknown>;
+		if (options?.asJSON) {
+			const obj: Record<string, unknown> = {};
+			for (const [name, value] of fields) {
+				if (name in obj) {
+					const current = obj[name];
+					obj[name] = Array.isArray(current) ? [...current, value] : [current, value];
+				} else {
+					obj[name] = value;
+				}
+			}
+			result = obj;
+		} else {
+			const params = new URLSearchParams();
+			for (const [name, value] of fields) {
+				params.append(name, value);
+			}
+			result = params.toString();
+		}
+
+		callback?.({
+			fragment: result,
+			be: this.beElement,
+			root: this.beElement
+		});
+
+		return result;
+	}
+
+	/**
+	 * Returns the form's elements (`Array.from(form.elements)`).
+	 * @param callback - Optional callback receiving the elements array as `fragment`.
+	 * @returns The form elements.
+	 */
+	getElements(callback?: HandlerCallBackFn): HTMLElement[] {
+		const ret: HTMLElement[] = [];
+		this.beElement.eachNode((el) => {
+			if (el instanceof HTMLFormElement) {
+				ret.push(...(Array.from(el.elements) as HTMLElement[]));
+			}
+		});
+
+		callback?.({
+			fragment: ret,
+			be: this.beElement,
+			root: this.beElement
+		});
+
+		return ret;
+	}
+
+	/**
+	 * Returns the value of a single field the Be instance wraps. The extraction
+	 * rule differs by input type: checkbox/radio → checked state,
+	 * `<select multiple>` → array of selected values, everything else → `.value`.
+	 * @param callback - Optional callback receiving the value as `fragment`.
+	 * @returns The field value, or undefined when no field is wrapped.
+	 * @example
+	 * be('#agree').fieldValue(); // true (checked checkbox)
+	 * be('#tags').fieldValue(); // ['a', 'b'] (multi-select)
+	 */
+	getValue(callback?: HandlerCallBackFn): FormFieldValue | undefined {
+		let value: FormFieldValue | undefined;
+
+		this.beElement.eachNode((el) => {
+			if (value !== undefined) return;
+
+			if (el instanceof HTMLSelectElement && el.multiple) {
+				value = Array.from(el.selectedOptions).map((option) => option.value);
+			} else if (el instanceof HTMLInputElement && (el.type === 'checkbox' || el.type === 'radio')) {
+				value = el.checked;
+			} else if (
+				el instanceof HTMLInputElement ||
+				el instanceof HTMLSelectElement ||
+				el instanceof HTMLTextAreaElement
+			) {
+				value = el.value;
+			}
+		}, true);
+
+		callback?.({
+			fragment: value,
+			be: this.beElement,
+			root: this.beElement
+		});
+
+		return value;
+	}
+
+	/**
+	 * Collects [name, value] pairs from every wrapped form, applying the
+	 * standard submission rules (skip disabled/nameless, only checked
+	 * checkboxes/radios, every selected option of multi-selects).
+	 */
+	private collectFields(): [string, string][] {
+		const pairs: [string, string][] = [];
+
+		this.beElement.eachNode((el) => {
+			const fields =
+				el instanceof HTMLFormElement
+					? (Array.from(el.elements) as HTMLElement[])
+					: FormHandler.isField(el)
+						? [el]
+						: [];
+
+			for (const field of fields) {
+				if (!FormHandler.isField(field)) continue;
+				const name = field.name;
+				if (!name || field.disabled) continue;
+
+				if (field instanceof HTMLInputElement && (field.type === 'checkbox' || field.type === 'radio')) {
+					if (field.checked) pairs.push([name, field.value]);
+				} else if (field instanceof HTMLSelectElement && field.multiple) {
+					for (const option of Array.from(field.selectedOptions)) {
+						pairs.push([name, option.value]);
+					}
+				} else if (field instanceof HTMLInputElement && (field.type === 'submit' || field.type === 'button' || field.type === 'reset' || field.type === 'file')) {
+					// not serialized
+				} else {
+					pairs.push([name, field.value]);
+				}
+			}
+		});
+
+		return pairs;
+	}
+
+	private static isField(
+		el: HTMLElement
+	): el is HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement {
+		return (
+			el instanceof HTMLInputElement ||
+			el instanceof HTMLSelectElement ||
+			el instanceof HTMLTextAreaElement
+		);
+	}
+
+	valueOf(): Be {
+		return this.beElement;
+	}
+}

--- a/packages/idae-be/src/lib/modules/http.test.ts
+++ b/packages/idae-be/src/lib/modules/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { be } from '../be.js';
 
 describe('HttpHandler', () => {
@@ -8,6 +8,8 @@ describe('HttpHandler', () => {
 
 		// Mock fetch
 		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
 			text: vi.fn().mockResolvedValue('<p>Loaded content</p>')
 		}) as unknown as typeof fetch;
 	});
@@ -49,7 +51,7 @@ describe('HttpHandler', () => {
 			expect(be.html).toContain('<p>Loaded content</p>');
 		});
 
-		expect(fetch).toHaveBeenCalledWith('/content.html');
+		expect(fetch).toHaveBeenCalledWith('/content.html', {});
 	});
 
 	it('should insert content with three arguments using insertHttp', async () => {
@@ -57,7 +59,7 @@ describe('HttpHandler', () => {
 			expect(be.html).toContain('<p>Loaded content</p>');
 		});
 
-		expect(fetch).toHaveBeenCalledWith('/content.html');
+		expect(fetch).toHaveBeenCalledWith('/content.html', {});
 	});
 
 	it('should insert content at the default position (beforeend) using insertHttp', async () => {
@@ -65,6 +67,90 @@ describe('HttpHandler', () => {
 			expect(be.html).toContain('<p>Loaded content</p>');
 		});
 
-		expect(fetch).toHaveBeenCalledWith('/content.html');
+		expect(fetch).toHaveBeenCalledWith('/content.html', {});
+	});
+
+	it('should call onFailure and skip content injection on non-ok response', async () => {
+		const errorResponse = {
+			ok: false,
+			status: 500,
+			text: vi.fn().mockResolvedValue('<p>Error body</p>')
+		};
+		global.fetch = vi.fn().mockResolvedValue(errorResponse) as unknown as typeof fetch;
+
+		const onFailure = vi.fn();
+		const callback = vi.fn();
+
+		await be('#test').updateHttp('/content.html', { onFailure }, callback);
+
+		expect(onFailure).toHaveBeenCalledWith(errorResponse);
+		expect(callback).not.toHaveBeenCalled();
+		expect(document.getElementById('test')?.innerHTML).toBe('');
+	});
+
+	it('should call onFailure with null response when fetch throws', async () => {
+		const networkError = new Error('network down');
+		global.fetch = vi.fn().mockRejectedValue(networkError) as unknown as typeof fetch;
+
+		const onFailure = vi.fn();
+		const callback = vi.fn();
+
+		await be('#test').updateHttp('/content.html', { onFailure }, callback);
+
+		expect(onFailure).toHaveBeenCalledWith(null, networkError);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('should rethrow when fetch fails and no onFailure is provided', async () => {
+		global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+		await expect(be('#test').updateHttp('/content.html')).rejects.toThrow('network down');
+	});
+
+	it('should serialize params onto the URL', async () => {
+		await be('#test').updateHttp('/content.html', { params: { a: '1', b: 'two words' } });
+
+		expect(fetch).toHaveBeenCalledWith(
+			'/content.html?a=1&b=two+words',
+			expect.objectContaining({ method: 'GET' })
+		);
+	});
+
+	it('should abort the request after the timeout', async () => {
+		vi.useFakeTimers();
+		try {
+			global.fetch = vi.fn().mockImplementation(
+				(_url: string, init?: RequestInit) =>
+					new Promise((_resolve, reject) => {
+						init?.signal?.addEventListener('abort', () =>
+							reject(new DOMException('Aborted', 'AbortError'))
+						);
+					})
+			) as unknown as typeof fetch;
+
+			const onFailure = vi.fn();
+			const promise = be('#test').updateHttp('/content.html', { timeout: 100, onFailure });
+
+			await vi.advanceTimersByTimeAsync(150);
+			await promise;
+
+			expect(onFailure).toHaveBeenCalledWith(null, expect.any(DOMException));
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('should call onFailure for insertHttp on non-ok response', async () => {
+		const errorResponse = { ok: false, status: 404, text: vi.fn().mockResolvedValue('nope') };
+		global.fetch = vi.fn().mockResolvedValue(errorResponse) as unknown as typeof fetch;
+
+		const onFailure = vi.fn();
+		const callback = vi.fn();
+
+		await be('#test').insertHttp('/missing.html', 'beforeend', { onFailure }, callback);
+
+		expect(onFailure).toHaveBeenCalledWith(errorResponse);
+		expect(callback).not.toHaveBeenCalled();
+		expect(document.getElementById('test')?.innerHTML).toBe('');
 	});
 });

--- a/packages/idae-be/src/lib/modules/http.ts
+++ b/packages/idae-be/src/lib/modules/http.ts
@@ -7,19 +7,32 @@ enum httpMethods {
 	insert = 'insert'
 }
 
+export interface HttpRequestOptions {
+	method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	data?: Record<string, unknown>;
+	headers?: Record<string, string>;
+	/** Query-string parameters (serialized onto the URL, mainly for GET). */
+	params?: Record<string, string>;
+	/** Abort the request after this many milliseconds. */
+	timeout?: number;
+	/**
+	 * Invoked instead of the content callback when the response is not ok
+	 * (`!response.ok`) or the fetch throws. `response` is null on network
+	 * failure / timeout; `error` is set when the fetch threw.
+	 */
+	onFailure?: (response: Response | null, error?: unknown) => void;
+}
+
 export interface HttpHandlerHandle {
 	update?: {
 		url: string;
-		options?: {
-			method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
-			data?: Record<string, unknown>;
-			headers?: Record<string, string>;
-		};
+		options?: HttpRequestOptions;
 		callback?: HandlerCallBackFn;
 	};
 	insert?: {
 		url: string;
 		mode?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend';
+		options?: Pick<HttpRequestOptions, 'params' | 'timeout' | 'onFailure'>;
 		callback?: HandlerCallBackFn;
 	};
 }
@@ -50,7 +63,7 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 					this.update(props.url, props.options, props.callback);
 					break;
 				case 'insert':
-					this.insert(props.url, props.mode, props.callback);
+					this.insert(props.url, props.mode, props.options, props.callback);
 					break;
 			}
 		});
@@ -77,22 +90,10 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 	 */
 	async update(
 		url: string,
-		optionsOrCallback?:
-			| {
-					method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
-					data?: Record<string, unknown>;
-					headers?: Record<string, string>;
-			  }
-			| HandlerCallBackFn,
+		optionsOrCallback?: HttpRequestOptions | HandlerCallBackFn,
 		callback?: HandlerCallBackFn
 	) {
-		let options:
-			| {
-					method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
-					data?: Record<string, unknown>;
-					headers?: Record<string, string>;
-			  }
-			| undefined;
+		let options: HttpRequestOptions | undefined;
 
 		// Detect if the second argument is an options object or a callback function
 		if (typeof optionsOrCallback === 'function') {
@@ -101,14 +102,35 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 			options = optionsOrCallback;
 		}
 
-		const response = await fetch(url, {
-			method: options?.method || 'GET',
-			body: options?.data ? JSON.stringify(options.data) : undefined,
-			headers: {
-				'Content-Type': 'application/json',
-				...options?.headers
+		let response: Response;
+		try {
+			response = await this.request(
+				url,
+				{
+					method: options?.method || 'GET',
+					body: options?.data ? JSON.stringify(options.data) : undefined,
+					headers: {
+						'Content-Type': 'application/json',
+						...options?.headers
+					}
+				},
+				options
+			);
+		} catch (error) {
+			if (options?.onFailure) {
+				options.onFailure(null, error);
+				return this.beElement;
 			}
-		});
+			throw error;
+		}
+
+		if (!response.ok) {
+			if (options?.onFailure) {
+				options.onFailure(response);
+				return this.beElement;
+			}
+			throw new Error(`updateHttp: request failed with status ${response.status}`);
+		}
 
 		const content = await response.text();
 
@@ -122,6 +144,8 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 				root: this.beElement
 			});
 		});
+
+		return this.beElement;
 	}
 
 	/**
@@ -144,9 +168,11 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 	async insert(
 		url: string,
 		modeOrCallback?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend' | HandlerCallBackFn,
+		optionsOrCallback?: Pick<HttpRequestOptions, 'params' | 'timeout' | 'onFailure'> | HandlerCallBackFn,
 		callback?: HandlerCallBackFn
 	) {
 		let mode: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend' | undefined;
+		let options: Pick<HttpRequestOptions, 'params' | 'timeout' | 'onFailure'> | undefined;
 
 		// Detect if the second argument is a mode or a callback function
 		if (typeof modeOrCallback === 'function') {
@@ -155,7 +181,32 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 			mode = modeOrCallback;
 		}
 
-		const response = await fetch(url);
+		// Detect if the third argument is options or a callback function
+		if (typeof optionsOrCallback === 'function') {
+			callback = optionsOrCallback;
+		} else {
+			options = optionsOrCallback;
+		}
+
+		let response: Response;
+		try {
+			response = await this.request(url, {}, options);
+		} catch (error) {
+			if (options?.onFailure) {
+				options.onFailure(null, error);
+				return this.beElement;
+			}
+			throw error;
+		}
+
+		if (!response.ok) {
+			if (options?.onFailure) {
+				options.onFailure(response);
+				return this.beElement;
+			}
+			throw new Error(`insertHttp: request failed with status ${response.status}`);
+		}
+
 		const content = await response.text();
 
 		this.beElement.eachNode((el) => {
@@ -169,5 +220,36 @@ export class HttpHandler implements CommonHandler<HttpHandler, HttpHandlerHandle
 				root: this.beElement
 			});
 		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Performs the fetch with query params serialization and optional timeout.
+	 * @param url - The URL to fetch.
+	 * @param init - The fetch init options.
+	 * @param options - Optional params/timeout from HttpRequestOptions.
+	 * @returns The fetch Response.
+	 */
+	private request(
+		url: string,
+		init: RequestInit,
+		options?: Pick<HttpRequestOptions, 'params' | 'timeout'>
+	): Promise<Response> {
+		let finalUrl = url;
+		if (options?.params) {
+			const qs = new URLSearchParams(options.params).toString();
+			if (qs) finalUrl += (finalUrl.includes('?') ? '&' : '?') + qs;
+		}
+
+		if (!options?.timeout) {
+			return fetch(finalUrl, init);
+		}
+
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), options.timeout);
+		return fetch(finalUrl, { ...init, signal: controller.signal }).finally(() =>
+			clearTimeout(timer)
+		);
 	}
 }

--- a/packages/idae-be/src/lib/modules/position.test.ts
+++ b/packages/idae-be/src/lib/modules/position.test.ts
@@ -171,4 +171,65 @@ describe('PositionHandler', () => {
 			expect(target.style.top).toBe('-167.5px');
 		});
 	});
+
+	// === TESTS FOR getDimensions ===
+	describe('getDimensions', () => {
+		it('should be attached to Be', () => {
+			const instance = be('#test');
+			expect(typeof instance.getDimensions).toBe('function');
+			expect(typeof instance.cumulativeOffset).toBe('function');
+			expect(typeof instance.viewportOffset).toBe('function');
+		});
+
+		it('should return offsetWidth/offsetHeight through the callback fragment', () => {
+			const target = document.querySelector('#target') as HTMLElement;
+			Object.defineProperty(target, 'offsetWidth', { configurable: true, value: 150 });
+			Object.defineProperty(target, 'offsetHeight', { configurable: true, value: 75 });
+
+			be('#target').getDimensions(({ fragment }) => {
+				expect(fragment).toEqual({ width: 150, height: 75 });
+			});
+		});
+
+		it('should measure a display:none element and restore its inline styles', () => {
+			document.body.innerHTML = '<div id="hidden" style="display: none; width: 100px;"></div>';
+			const hidden = document.querySelector('#hidden') as HTMLElement;
+
+			Object.defineProperty(hidden, 'offsetWidth', {
+				configurable: true,
+				get() {
+					return this.style.display === 'none' ? 0 : 100;
+				}
+			});
+			Object.defineProperty(hidden, 'offsetHeight', {
+				configurable: true,
+				get() {
+					return this.style.display === 'none' ? 0 : 20;
+				}
+			});
+
+			be('#hidden').getDimensions(({ fragment }) => {
+				expect(fragment).toEqual({ width: 100, height: 20 });
+			});
+			expect(hidden.style.display).toBe('none');
+		});
+	});
+
+	// === TESTS FOR offsets ===
+	describe('offsets', () => {
+		it('should return the viewport offset through the callback fragment', () => {
+			be('#target').viewportOffset(({ fragment }) => {
+				expect(fragment).toEqual({ left: 300, top: 200 });
+			});
+		});
+
+		it('should return the cumulative offset (document-relative) through the callback fragment', () => {
+			be('#target').cumulativeOffset(({ fragment }) => {
+				expect(fragment).toEqual({
+					left: 300 + (window.scrollX || 0),
+					top: 200 + (window.scrollY || 0)
+				});
+			});
+		});
+	});
 });

--- a/packages/idae-be/src/lib/modules/position.test.ts
+++ b/packages/idae-be/src/lib/modules/position.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { be } from '../be.js';
 import { BeUtils } from '$lib/utils.js';
+import type { PositionSnapOptions } from '$lib/types.js';
 
 describe('Be class', () => {
 	// === TESTS FOR BE CLASS METHODS ===
@@ -80,7 +81,7 @@ describe('PositionHandler', () => {
 				bottom: 150,
 				right: 300
 			} as DOMRect;
-			const anchor = 'invalid';
+			const anchor = 'invalid' as PositionSnapOptions;
 
 			const [x, y] = BeUtils.calculateAnchorPoint(rect, anchor);
 			expect(x).toBe(100); // Default to rect.left

--- a/packages/idae-be/src/lib/modules/position.ts
+++ b/packages/idae-be/src/lib/modules/position.ts
@@ -10,7 +10,10 @@ import { BeUtils } from '../utils.js';
 enum positionMethods {
 	clonePosition = 'clonePosition',
 	overlapPosition = 'overlapPosition',
-	snapTo = 'snapTo'
+	snapTo = 'snapTo',
+	getDimensions = 'getDimensions',
+	cumulativeOffset = 'cumulativeOffset',
+	viewportOffset = 'viewportOffset'
 }
 
 export interface PositionHandlerHandle {
@@ -20,6 +23,9 @@ export interface PositionHandlerHandle {
 		options: PositionSnapOptions;
 	} & HandlerCallBack;
 	snapTo?: { target: string | HTMLElement; options?: PositionSnapOptions } & HandlerCallBack;
+	getDimensions?: HandlerCallBack;
+	cumulativeOffset?: HandlerCallBack;
+	viewportOffset?: HandlerCallBack;
 }
 export class PositionHandler implements CommonHandler<PositionHandler, PositionHandlerHandle> {
 	private beElement: Be;
@@ -42,6 +48,15 @@ export class PositionHandler implements CommonHandler<PositionHandler, PositionH
 					break;
 				case 'snapTo':
 					this.snapTo(props.target, props.options, props.callback);
+					break;
+				case 'getDimensions':
+					this.getDimensions(props.callback);
+					break;
+				case 'cumulativeOffset':
+					this.cumulativeOffset(props.callback);
+					break;
+				case 'viewportOffset':
+					this.viewportOffset(props.callback);
 					break;
 			}
 		});
@@ -243,6 +258,106 @@ export class PositionHandler implements CommonHandler<PositionHandler, PositionH
 		});
 
 		return this.beElement;
+	}
+
+	/**
+	 * Returns the dimensions of the element. For elements with `display: none`,
+	 * the element is temporarily made measurable (`position: absolute;
+	 * visibility: hidden; display: block`), measured, then restored.
+	 * The result is passed to the callback via `fragment`.
+	 * @param callback - Optional callback receiving `{ width, height }` as `fragment`.
+	 * @returns The Be instance for method chaining.
+	 * @example
+	 * be('#box').getDimensions(({ fragment }) => console.log(fragment)); // { width: 120, height: 40 }
+	 */
+	getDimensions(callback?: HandlerCallBackFn): Be {
+		this.beElement.eachNode((el) => {
+			const dimensions = PositionHandler.measure(el);
+			callback?.({
+				fragment: dimensions,
+				be: be(el),
+				root: this.beElement
+			});
+		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Returns the element's position relative to the document, accounting for scroll.
+	 * The result is passed to the callback via `fragment`.
+	 * @param callback - Optional callback receiving `{ left, top }` as `fragment`.
+	 * @returns The Be instance for method chaining.
+	 * @example
+	 * be('#box').cumulativeOffset(({ fragment }) => console.log(fragment)); // { left: 10, top: 240 }
+	 */
+	cumulativeOffset(callback?: HandlerCallBackFn): Be {
+		this.beElement.eachNode((el) => {
+			const rect = el.getBoundingClientRect();
+			const offset = {
+				left: rect.left + (window.scrollX || window.pageXOffset || 0),
+				top: rect.top + (window.scrollY || window.pageYOffset || 0)
+			};
+			callback?.({
+				fragment: offset,
+				be: be(el),
+				root: this.beElement
+			});
+		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Returns the element's position relative to the viewport
+	 * (`getBoundingClientRect()` directly, no scroll adjustment).
+	 * The result is passed to the callback via `fragment`.
+	 * @param callback - Optional callback receiving `{ left, top }` as `fragment`.
+	 * @returns The Be instance for method chaining.
+	 * @example
+	 * be('#box').viewportOffset(({ fragment }) => console.log(fragment)); // { left: 10, top: 32 }
+	 */
+	viewportOffset(callback?: HandlerCallBackFn): Be {
+		this.beElement.eachNode((el) => {
+			const rect = el.getBoundingClientRect();
+			const offset = { left: rect.left, top: rect.top };
+			callback?.({
+				fragment: offset,
+				be: be(el),
+				root: this.beElement
+			});
+		});
+
+		return this.beElement;
+	}
+
+	/**
+	 * Measures an element's dimensions, temporarily making it measurable when
+	 * it is not rendered (`display: none`).
+	 */
+	private static measure(el: HTMLElement): { width: number; height: number } {
+		if (el.offsetWidth !== 0 || el.offsetHeight !== 0) {
+			return { width: el.offsetWidth, height: el.offsetHeight };
+		}
+
+		const computed = window.getComputedStyle(el);
+		if (computed.display !== 'none') {
+			return { width: el.offsetWidth, height: el.offsetHeight };
+		}
+
+		const original = {
+			position: el.style.position,
+			visibility: el.style.visibility,
+			display: el.style.display
+		};
+		el.style.position = 'absolute';
+		el.style.visibility = 'hidden';
+		el.style.display = 'block';
+		const dimensions = { width: el.offsetWidth, height: el.offsetHeight };
+		el.style.position = original.position;
+		el.style.visibility = original.visibility;
+		el.style.display = original.display;
+		return dimensions;
 	}
 
 	valueOf(): DOMRect | null {

--- a/packages/idae-be/src/lib/modules/styles.ts
+++ b/packages/idae-be/src/lib/modules/styles.ts
@@ -105,19 +105,25 @@ export class StylesHandler implements CommonHandler<StylesHandler, Partial<BeSty
 	 * const color = beInstance.getStyle('color');
 	 * console.log(color); // Output: "red"
 	 */
+	/**
+	 * Gets the inline value of a CSS property for the first matched element.
+	 * Only inline styles (set via `setStyle` or the `style` attribute) are read —
+	 * values coming from stylesheets are not resolved, so a property that was
+	 * never set (or was removed with `unsetStyle`) returns null.
+	 * @param key - The CSS property name (camelCase or kebab-case).
+	 * @returns The value of the CSS property, or null if not set inline.
+	 * @example
+	 * // HTML: <div id="test" style="color: red;"></div>
+	 * const beInstance = be('#test');
+	 * const color = beInstance.getStyle('color');
+	 * console.log(color); // Output: "red"
+	 */
 	get(key: string): string | null {
 		let css: string | null = null;
 		this.beElement.eachNode((el) => {
-			// Prioritize inline styles
-			css = el.style[key as any] || null;
-
-			// Fallback to computed styles if inline style is not set
-			if (!css) {
-				const computedStyle = window.getComputedStyle(el);
-				css = computedStyle.getPropertyValue(key).trim();
-			}
+			css = el.style.getPropertyValue(toKebabCase(key)).trim() || null;
 		}, true);
-		return css || null;
+		return css;
 	}
 	/**
 	 * Removes a CSS property from the selected element(s).

--- a/packages/idae-be/src/lib/modules/styles.ts
+++ b/packages/idae-be/src/lib/modules/styles.ts
@@ -35,13 +35,13 @@ export class StylesHandler implements CommonHandler<StylesHandler, Partial<BeSty
 		this.beElement.eachNode(() => {
 			switch (method) {
 				case 'set':
-					this.set(args);
+					this.set(args as Record<string, string> | string);
 					break;
 				case 'get':
-					this.get(args);
+					this.get(args as string);
 					break;
 				case 'unset':
-					this.unset(args);
+					this.unset(args as string);
 					break;
 			}
 		});

--- a/packages/idae-be/src/lib/modules/text.ts
+++ b/packages/idae-be/src/lib/modules/text.ts
@@ -25,7 +25,7 @@ export type TextHandlerHandle = {
 	callback?: (element: HandlerCallbackProps) => void;
 };
 
-export class TextHandler implements CommonHandler<TextHandler> {
+export class TextHandler implements CommonHandler<TextHandler, TextHandlerHandle> {
 	private beElement: Be;
 
 	static methods = Object.values(textMethods);

--- a/packages/idae-be/src/lib/modules/timers.test.ts
+++ b/packages/idae-be/src/lib/modules/timers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { be } from '../be.js';
 
 describe('TimersHandler', () => {

--- a/packages/idae-be/src/lib/modules/walk.test.ts
+++ b/packages/idae-be/src/lib/modules/walk.test.ts
@@ -26,9 +26,14 @@ describe('WalkHandler', () => {
             </div>
         `;
 
-		const parent = be('#child').up();
+		let parent: Be | undefined;
+		const root = be('#child').up(({ be: up }) => {
+			parent = up;
+		});
 
+		expect(root.node).toBe(document.getElementById('child'));
 		expect(parent).toBeInstanceOf(Be);
+		expect((parent?.node as HTMLElement[])[0]).toBe(document.getElementById('parent'));
 	});
 
 	it('should find siblings', () => {

--- a/packages/idae-be/src/lib/modules/walk.test.ts
+++ b/packages/idae-be/src/lib/modules/walk.test.ts
@@ -46,7 +46,7 @@ describe('WalkHandler', () => {
         `;
 
 		be('#target').siblings(({ be: siblings }) => {
-			expect(siblings.node.length).toBe(2);
+			expect((siblings.node as HTMLElement[]).length).toBe(2);
 		});
 	});
 

--- a/packages/idae-be/src/lib/modules/walk.ts
+++ b/packages/idae-be/src/lib/modules/walk.ts
@@ -351,6 +351,10 @@ export class WalkHandler
 			requested: Be.elem(ret)
 		});
 
+		// Contract: traversal methods always return the root (`this.beElement`);
+		// results are reached through `callback`'s `be`. methodize()-built
+		// methods (up/next/previous/children/closest/firstChild/lastChild)
+		// follow the same rule.
 		return this.beElement;
 	}
 
@@ -375,7 +379,7 @@ export class WalkHandler
 					fragment: 'result',
 					requested: resultBe
 				});
-				return resultBe;
+				return this.beElement;
 			} catch (e) {
 				console.error(`Error in methodize for ${method}:`, e);
 			}

--- a/packages/idae-be/src/lib/modules/walk.ts
+++ b/packages/idae-be/src/lib/modules/walk.ts
@@ -232,7 +232,9 @@ export class WalkHandler
 		const ret: HTMLElement[] = [];
 		this.beElement.eachNode((el: HTMLElement) => {
 			if (el.parentNode) {
-				const siblings = Array.from(el.parentNode.children).filter((child) => child !== el);
+				const siblings = Array.from(el.parentNode.children).filter(
+					(child) => child !== el
+				) as HTMLElement[];
 				ret.push(...siblings.filter((sibling) => !qy || sibling.matches(qy)));
 			}
 		});
@@ -342,7 +344,7 @@ export class WalkHandler
 	findAll(qy: string, callback?: HandlerCallBackFn): Be | null {
 		const ret: HTMLElement[] = [];
 		this.beElement.eachNode((el: HTMLElement) => {
-			ret.push(...Array.from(el.querySelectorAll(qy)));
+			ret.push(...(Array.from(el.querySelectorAll(qy)) as HTMLElement[]));
 		});
 		callback?.({
 			root: this.beElement,
@@ -429,7 +431,9 @@ export class WalkHandler
 		if (direction === 'siblings') {
 			const parent = element.parentElement;
 			if (!parent) return [];
-			const siblings = Array.from(parent.children).filter((child) => child !== element);
+			const siblings = Array.from(parent.children).filter(
+				(child) => child !== element
+			) as HTMLElement[];
 			return selector ? siblings.filter((sibling) => sibling.matches(selector)) : siblings;
 		}
 

--- a/packages/idae-be/src/lib/skill/idae-be/SKILL.md
+++ b/packages/idae-be/src/lib/skill/idae-be/SKILL.md
@@ -39,8 +39,10 @@ be('#btn').on('click', () => {
 // Load remote HTML into an element
 be('#content').updateHttp('/partials/dashboard.html');
 
-// Walk the DOM and mutate results
-be('#list').children('li').without('.disabled').addClass('selectable');
+// Walk the DOM and mutate results (results come through the callback)
+be('#list').children('li', ({ be: items }) => {
+  items.without('.disabled', ({ be: enabled }) => enabled.addClass('selectable'));
+});
 
 // Delayed action
 be('#toast').addClass('show').timeout(() => {

--- a/packages/idae-be/src/lib/skill/idae-be/SKILL.md
+++ b/packages/idae-be/src/lib/skill/idae-be/SKILL.md
@@ -58,13 +58,17 @@ be('#toast').addClass('show').timeout(() => {
 | **Classes** | `addClass` `removeClass` `toggleClass` `replaceClass` | `classes({add,remove,toggle,replace})` |
 | **Attributes** | `setAttr` `getAttr` `deleteAttr` | `attrs({set,get,delete})` |
 | **Dataset** | `setData` `getData` `deleteData` `getKey` | `data({set,get,delete,getKey})` |
-| **Events** | `on` `off` `fire` | `events({on,off,fire})` |
+| **Events** | `on` `off` `fire` (incl. delegated `on(event, selector, handler)`) | `events({on,off,fire})` |
 | **DOM** | `update` `append` `prepend` `insert` `remove` `replace` `wrap` `unwrap` `clear` `normalize` | `dom({...})` |
 | **Text** | `updateText` `appendText` `prependText` `replaceText` `removeText` `clearText` `normalizeText` `wrapText` | `text({...})` |
 | **Walk** | `up` `next` `previous` `siblings` `children` `closest` `find` `findAll` `firstChild` `lastChild` `without` | `walk({...})` |
-| **HTTP** | `updateHttp` `insertHttp` | `http({update,insert})` |
-| **Position** | `clonePosition` `overlapPosition` `snapTo` | `position({...})` |
+| **HTTP** | `updateHttp` `insertHttp` (with `onFailure`/`timeout`/`params`) | `http({update,insert})` |
+| **Position** | `clonePosition` `overlapPosition` `snapTo` `getDimensions` `cumulativeOffset` `viewportOffset` | `position({...})` |
+| **Forms** | `serializeForm` `fieldValue` `getFormElements` | `form({serialize,getElements,getValue})` |
+| **Effects** | `fade` `appear` `slideUp` `slideDown` `move` `scale` (Web Animations API) | `effects({...})` |
 | **Timers** | `timeout` `interval` `clearTimeout` `clearInterval` | `timers({...})` |
+
+Standalone utilities (plain functions, not handlers): `toArray`, `toWords`, `range`, `createClass`, `extendObject`.
 
 ## Key concepts
 

--- a/packages/idae-be/src/lib/skill/idae-be/references/api-reference.md
+++ b/packages/idae-be/src/lib/skill/idae-be/references/api-reference.md
@@ -156,10 +156,27 @@ data(actions: Partial<{
 ```ts
 on(eventName: string, handler: EventListener, options?: EventListenerOptions, callback?: HandlerCallBackFn): Be
 
+// Delegated form — fires only when the event target matches a descendant fitting `selector`;
+// handler is invoked with `this` set to the matched descendant (not the bound root)
+on(eventName: string, selector: string, handler: EventListener, options?: EventListenerOptions, callback?: HandlerCallBackFn): Be
+
 off(eventName: string, handler: EventListener, options?: EventListenerOptions, callback?: HandlerCallBackFn): Be
+
+// Removes a delegated listener registered with the same (eventName, selector, handler) triple
+off(eventName: string, selector: string, handler: EventListener, options?: EventListenerOptions, callback?: HandlerCallBackFn): Be
 
 fire(eventName: string, detail?: unknown, options?: EventInit, callback?: HandlerCallBackFn): Be
 // Dispatches a CustomEvent — detail is passed as event.detail
+```
+
+**Delegated example:**
+
+```ts
+// One listener on the list, works for items added later
+be('#list').on('click', 'li.item', function (e) {
+  be(this as HTMLElement).toggleClass('selected');
+});
+be('#list').off('click', 'li.item', handler); // removed by the same triple
 ```
 
 **Handler API:**
@@ -343,26 +360,41 @@ walk(actions: {
 
 Fetches HTML from a URL and injects it into the element. Uses `fetch` internally.
 
+**`HttpRequestOptions`:**
+
+```ts
+interface HttpRequestOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  data?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  params?: Record<string, string>;  // serialized onto the URL (query string)
+  timeout?: number;                 // aborts the request after N ms (AbortController)
+  onFailure?: (response: Response | null, error?: unknown) => void;
+  // called INSTEAD of the content callback when !response.ok (response set)
+  // or the fetch throws / times out (response null, error set).
+  // Without onFailure, failures throw.
+}
+```
+
 **Direct methods:**
 
 ```ts
 updateHttp(
   url: string,
-  optionsOrCallback?: {
-    method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
-    data?: Record<string, unknown>;
-    headers?: Record<string, string>;
-  } | HandlerCallBackFn,
+  optionsOrCallback?: HttpRequestOptions | HandlerCallBackFn,
   callback?: HandlerCallBackFn
 ): Promise<Be>
-// Fetches HTML and replaces element's innerHTML
+// Fetches HTML and replaces element's innerHTML.
+// A non-ok response is NOT injected: onFailure is called (or the error is thrown).
 
 insertHttp(
   url: string,
   mode?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend',
+  options?: Pick<HttpRequestOptions, 'params' | 'timeout' | 'onFailure'>,
   callback?: HandlerCallBackFn
 ): Promise<Be>
 // Fetches HTML and inserts at position (default: beforeend)
+// `callback` may take the options slot when options are omitted.
 ```
 
 **Handler API:**
@@ -371,15 +403,22 @@ insertHttp(
 http(actions: {
   update?: {
     url: string;
-    options?: { method?: string; data?: Record<string, unknown>; headers?: Record<string, string> };
+    options?: HttpRequestOptions;
     callback?: HandlerCallBackFn;
   };
   insert?: {
     url: string;
     mode?: 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend';
+    options?: Pick<HttpRequestOptions, 'params' | 'timeout' | 'onFailure'>;
     callback?: HandlerCallBackFn;
   };
 }): Be
+```
+
+**`Be.fetch` (JSON helper)** also supports `params` and `timeout`, and throws on non-ok responses:
+
+```ts
+be().fetch({ url: '/api/items', params: { page: '1' }, timeout: 5000 }); // Promise<unknown> (parsed JSON)
 ```
 
 ---
@@ -416,6 +455,21 @@ snapTo(
   callback?: HandlerCallBackFn
 ): Be
 // Snaps this element to a grid/target position
+
+getDimensions(callback?: HandlerCallBackFn): Be
+// { width, height } via callback fragment. display:none elements are temporarily
+// made measurable (position:absolute; visibility:hidden; display:block), measured, restored.
+
+cumulativeOffset(callback?: HandlerCallBackFn): Be
+// { left, top } relative to the document (rect + scroll), via callback fragment.
+
+viewportOffset(callback?: HandlerCallBackFn): Be
+// { left, top } relative to the viewport (getBoundingClientRect), via callback fragment.
+```
+
+```ts
+be('#box').getDimensions(({ fragment }) => console.log(fragment));   // { width: 120, height: 40 }
+be('#box').viewportOffset(({ fragment }) => console.log(fragment));  // { left: 10, top: 32 }
 ```
 
 **`PositionSnapOptions` type:**
@@ -465,6 +519,115 @@ clearInterval(): Be
   method?:  string;    // 'timeout' | 'interval'
 }
 ```
+
+---
+
+## Forms module
+
+Form serialization and per-field value access. Wired explicitly on `Be`
+(not via the generic attach) to expose unambiguous names.
+
+**Direct methods:**
+
+```ts
+serializeForm(options?: { asJSON?: boolean }, callback?: HandlerCallBackFn): string | Record<string, unknown>
+// URL-encoded query string by default; plain object with asJSON.
+// Skips disabled/nameless fields, unchecked checkboxes/radios, buttons and file inputs.
+// <select multiple> → repeated entries (query string) or array of values (asJSON).
+
+fieldValue(callback?: HandlerCallBackFn): string | string[] | boolean | undefined
+// Value of a single wrapped field: checkbox/radio → checked state,
+// <select multiple> → array of selected values, anything else → .value.
+
+getFormElements(callback?: HandlerCallBackFn): HTMLElement[]
+// Array.from(form.elements)
+```
+
+**Handler API:**
+
+```ts
+form(actions: {
+  serialize?:   { options?: { asJSON?: boolean }; callback?: HandlerCallBackFn };
+  getElements?: { callback?: HandlerCallBackFn };
+  getValue?:    { callback?: HandlerCallBackFn };
+}): Be
+```
+
+```ts
+be('#myForm').serializeForm();                  // "name=john&tags=a&tags=b"
+be('#myForm').serializeForm({ asJSON: true });  // { name: 'john', tags: ['a', 'b'] }
+be('#agree').fieldValue();                      // true (checked checkbox)
+```
+
+---
+
+## Effects module
+
+Animation helpers on the native Web Animations API (`el.animate`) — no dependency.
+When `el.animate` is unavailable, final styles are applied synchronously and the
+callback fires immediately.
+
+**Direct methods** (all take `options` + `callback`, return the root `Be`):
+
+```ts
+fade(options?: EffectOptions, callback?: HandlerCallBackFn): Be
+// opacity → 0, then display:none
+
+appear(options?: EffectOptions, callback?: HandlerCallBackFn): Be
+// opacity 0 → 1 (unhides first if display:none)
+
+slideUp(options?: EffectOptions, callback?: HandlerCallBackFn): Be
+// collapses height, then display:none
+
+slideDown(options?: EffectOptions, callback?: HandlerCallBackFn): Be
+// expands height from hidden
+
+move(options?: MoveOptions, callback?: HandlerCallBackFn): Be
+// { x?, y? } px translation, left applied as final style
+
+scale(options?: ScaleOptions, callback?: HandlerCallBackFn): Be
+// { from?, to? } scale factors, left applied as final style
+
+interface EffectOptions { duration?: number; easing?: string; delay?: number } // defaults: 400, 'ease', 0
+```
+
+**Handler API:**
+
+```ts
+effects(actions: {
+  fade?:      { options?: EffectOptions; callback?: HandlerCallBackFn };
+  appear?:    { options?: EffectOptions; callback?: HandlerCallBackFn };
+  slideUp?:   { options?: EffectOptions; callback?: HandlerCallBackFn };
+  slideDown?: { options?: EffectOptions; callback?: HandlerCallBackFn };
+  move?:      { options?: MoveOptions;   callback?: HandlerCallBackFn };
+  scale?:     { options?: ScaleOptions;  callback?: HandlerCallBackFn };
+}): Be
+```
+
+```ts
+be('#toast').appear({ duration: 200 });
+be('#panel').slideUp({ duration: 300 }, ({ be }) => console.log('collapsed'));
+```
+
+---
+
+## Collection & class utilities
+
+Plain exported functions (not handlers — they operate on values, not elements).
+
+```ts
+toArray<T>(iterableOrArrayLike: Iterable<T> | ArrayLike<T>): T[]
+toWords(str: string): string[]                      // whitespace-split, empties dropped
+range(start: number, end: number, exclusive?: boolean): number[]  // inclusive by default, descending ok
+
+createClass(spec: Record<string, Function>, Base?: Function): new (...args: unknown[]) => object
+// Builds an ES class at runtime; spec.initialize acts as constructor body.
+// Prefer native `class` syntax unless the spec itself is dynamic.
+
+extendObject<T, S>(target: T, source: S): T & S     // Object.assign semantics
+```
+
+For key/value stores, prefer the native `Map` — no Hash-like class is shipped.
 
 ---
 

--- a/packages/idae-be/src/lib/skill/idae-be/references/patterns.md
+++ b/packages/idae-be/src/lib/skill/idae-be/references/patterns.md
@@ -128,13 +128,15 @@ be('#myForm').on('submit', (e) => {
   e.preventDefault();
   let valid = true;
 
-  be('#myForm input[required]').findAll('input').eachNode?.((input: HTMLElement) => {
-    if (!(input as HTMLInputElement).value.trim()) {
-      be(input).addClass('error').setAttr('aria-invalid', 'true');
-      valid = false;
-    } else {
-      be(input).removeClass('error').deleteAttr('aria-invalid');
-    }
+  be('#myForm input[required]').findAll('input', ({ be: inputs }) => {
+    inputs.eachNode((input: HTMLElement) => {
+      if (!(input as HTMLInputElement).value.trim()) {
+        be(input).addClass('error').setAttr('aria-invalid', 'true');
+        valid = false;
+      } else {
+        be(input).removeClass('error').deleteAttr('aria-invalid');
+      }
+    });
   });
 
   if (!valid) {

--- a/packages/idae-be/src/lib/utils.ts
+++ b/packages/idae-be/src/lib/utils.ts
@@ -6,7 +6,7 @@ interface isHTMLReturn {
 	tag: string;
 	attributes: { [key: string]: string };
 	styles: { [key: string]: string };
-	node: HTMLElement;
+	node?: HTMLElement;
 	beElem?: Be;
 	content?: string;
 }
@@ -132,33 +132,33 @@ export class BeUtils {
 		});
 	}
 
-	static applyCallback(el: HTMLElement | HTMLCollection, callback: (el: HTMLElement) => void) {
+	static applyCallback(el: HTMLElement | Element | HTMLCollection, callback: (el: HTMLElement) => void) {
 		if (el instanceof HTMLCollection) {
 			return Array.from(el).forEach((ss) => {
 				BeUtils.applyCallback(ss, callback);
 			});
 		} else {
-			return callback(el);
+			return callback(el as HTMLElement);
 		}
 	}
 
 	static resolveIndirection<T = CommonHandler>(
-		classHandler: CommonHandler,
-		actions: keyof T
+		classHandler: { methods: string[] | unknown },
+		actions: Partial<Record<keyof T, unknown>>
 	): {
 		method: keyof T;
 		props: any;
 	} {
-		let method: keyof T;
-		let props;
+		let method: keyof T | undefined;
+		let props: unknown;
 
-		Object.keys(actions).forEach((action) => {
-			if (classHandler.methods.includes(action)) {
+		(Object.keys(actions) as Array<keyof T>).forEach((action) => {
+			if ((classHandler.methods as string[]).includes(action as string)) {
 				method = action;
-				props = actions[action as keyof T];
+				props = actions[action];
 			}
 		});
 
-		return { method, props };
+		return { method: method as keyof T, props };
 	}
 }

--- a/packages/idae-slotui/src/lib/index.ts
+++ b/packages/idae-slotui/src/lib/index.ts
@@ -236,7 +236,6 @@ export * as popperCss from '$lib/ui/popper/popper.css';
 export { default as Popper } from '$lib/ui/popper/Popper.svelte';
 export * from '$lib/ui/popper/types.js';
 export * from '$lib/ui/popper/usePopper.js';
-export { default as Preview } from '$lib/ui/preview/Preview.svelte';
 export { default as PreviewZoom } from '$lib/ui/preview/PreviewZoom.svelte';
 export * from '$lib/ui/preview/types.js';
 export { default as ServiceBox } from '$lib/ui/serviceBox/ServiceBox.svelte';

--- a/packages/idae-slotui/src/lib/styles/slotuisheet/SlotyuiSheet.demo.svelte
+++ b/packages/idae-slotui/src/lib/styles/slotuisheet/SlotyuiSheet.demo.svelte
@@ -15,8 +15,10 @@
 			be(element).classAdd(objTag.class).setStyle(objTag.style);
 			console.log(element, changes);
 
-			be(element).up('[container]').setStyle(objTag.style);
-			console.log(be(element).up('[container]').node);
+			be(element).up('[container]', ({ be: container }) => {
+				container.setStyle(objTag.style);
+				console.log(container.node);
+			});
 		}
 	});
 </script>

--- a/packages/idae-slotui/src/lib/utils/stylesheet/StyleSheet.demo.svelte
+++ b/packages/idae-slotui/src/lib/utils/stylesheet/StyleSheet.demo.svelte
@@ -15,8 +15,10 @@
 			be(element).classAdd(objTag.class).setStyle(objTag.style);
 			console.log(element, changes);
 
-			be(element).up('[container]').setStyle(objTag.style);
-			console.log(be(element).up('[container]').node);
+			be(element).up('[container]', ({ be: container }) => {
+				container.setStyle(objTag.style);
+				console.log(container.node);
+			});
 		}
 	});
 </script>


### PR DESCRIPTION
## idae-be 1.97.0 — TODO roadmap complète

Implémentation intégrale de `packages/idae-be/TODO.md` (§1 + §2.1→§2.7), plus correction des erreurs TypeScript pré-existantes (`tsc --noEmit` : **0 erreur**) et des 2 échecs de tests pré-existants (**111/111 tests verts**).

### Features
- **§2.1 Événements** : délégation `on(event, selector, handler)` / `off(...)` — un seul listener par nœud, handler invoqué avec l'élément matché, retrait via le même triplet (registre `WeakMap` statique)
- **§2.2 Forms** : nouveau `FormHandler` — `serializeForm` (query string / `asJSON`), `fieldValue` (checkbox/radio → checked, multi-select → tableau), `getFormElements`
- **§2.3 Collections** : `toArray` / `toWords` / `range` (fonctions exportées ; `Map` natif recommandé plutôt qu'une classe Hash)
- **§2.4 Classes** : `createClass` / `extendObject` avec réserve documentée vs `class` natif
- **§2.5 Effects** : nouveau `EffectsHandler` — `fade`/`appear`/`slideUp`/`slideDown`/`move`/`scale` sur Web Animations API native + fallback synchrone sans `el.animate`
- **§2.6 HTTP** : `onFailure` / `timeout` (AbortController) / `params` sur `updateHttp`/`insertHttp` et `Be.fetch`
- **§2.7 Position** : `getDimensions` (compatible `display:none`), `cumulativeOffset`, `viewportOffset`

### Fixes
- **§1 walk** : `methodize()` retourne la racine `Be` (contrat callback-only) — fin du chaînage jQuery implicite ; call sites audités et migrés (tests, docs skill, démos idae-slotui)
- **styles** : `get()` lit uniquement l'inline et retourne `null` quand non défini (contrat documenté)
- **types** : 22 erreurs TS pré-existantes corrigées (proxyHandler, utils, data, text, walk…)

### ⚠️ Breaking changes
- Les méthodes de traversal (`up`/`next`/`previous`/`children`/`closest`/`firstChild`/`lastChild`/`findAll`) retournent toujours la racine — résultats via callback uniquement
- `updateHttp`/`insertHttp` sans `onFailure` rejettent désormais sur réponse non-ok (plus d'injection du corps d'erreur)
- `Be.fetch` rejette sur réponse non-ok au lieu de parser le corps d'erreur en JSON
- `getStyle` ne retombe plus sur `getComputedStyle` (inline uniquement)

### Docs
README, SKILL.md, api-reference.md et CHANGELOG 1.97.0 mis à jour.