### PR TITLE
docs(idae-be): sync integration-guide with 1.97.0 (forms, effects, return contract)

### DIFF
--- a/packages/idae-be/src/lib/skill/idae-be/references/integration-guide.md
+++ b/packages/idae-be/src/lib/skill/idae-be/references/integration-guide.md
@@ -9,16 +9,24 @@ be(selector)
        ├─ ClassesHandler   → addClass / removeClass / toggleClass / replaceClass
        ├─ AttrHandler      → setAttr / getAttr / deleteAttr
        ├─ DataHandler      → setData / getData / deleteData / getKey
-       ├─ EventsHandler    → on / off / fire
+       ├─ EventsHandler    → on / off / fire  (incl. delegated on(event, selector, handler))
        ├─ DomHandler       → update / append / prepend / insert / remove / replace / wrap / unwrap / clear
        ├─ TextHandler      → updateText / appendText / prependText / replaceText / clearText / normalizeText / wrapText
        ├─ WalkHandler      → up / next / previous / siblings / children / closest / find / findAll / firstChild / lastChild / without
-       ├─ HttpHandler      → updateHttp / insertHttp
-       ├─ PositionHandler  → clonePosition / overlapPosition / snapTo
+       ├─ HttpHandler      → updateHttp / insertHttp  (onFailure / timeout / params)
+       ├─ PositionHandler  → clonePosition / overlapPosition / snapTo / getDimensions / cumulativeOffset / viewportOffset
+       ├─ FormHandler      → serializeForm / fieldValue / getFormElements  (wired explicitly, not via attach())
+       ├─ EffectsHandler   → fade / appear / slideUp / slideDown / move / scale  (Web Animations API)
        └─ TimersHandler    → timeout / interval / clearTimeout / clearInterval
+
+Standalone exports (not handlers): toArray / toWords / range / createClass / extendObject
 ```
 
-Each handler is instantiated once per `Be` instance. Methods are attached directly on `Be` via `attach()` so they are callable as shorthands.
+Each handler is instantiated once per `Be` instance. Methods are attached directly on `Be` via `attach()` so they are callable as shorthands — except `FormHandler`, which is wired explicitly to expose unambiguous names (`serializeForm`, `fieldValue`, `getFormElements`).
+
+**Return contract:** every method returns the root `Be`. Traversal results are
+reached through the callback (`up/next/children/closest/...`) — never by
+chaining off a traversal method's return value.
 
 ---
 
@@ -163,10 +171,9 @@ import { proxyHandler } from '@medyll/idae-be';
   let container: HTMLElement;
 
   onMount(() => {
-    be(container)
-      .find('.lazy-img')
-      .setAttr('src', '/images/hero.webp')
-      .addClass('loaded');
+    be(container).find('.lazy-img', ({ be: img }) => {
+      img.setAttr('src', '/images/hero.webp').addClass('loaded');
+    });
   });
 </script>
 


### PR DESCRIPTION
Mise à jour de `integration-guide.md` (suite de #133) :

- Diagramme d'architecture : ajout de `FormHandler`, `EffectsHandler`, des nouvelles méthodes `PositionHandler`, de la délégation d'événements et des options HTTP
- Note sur le contrat de retour (les méthodes de traversal retournent la racine, résultats via callback)
- Correction de l'exemple Svelte 5 qui chaînait sur `find()` (forme callback désormais)
- Mention des utilitaires standalone (`toArray`/`toWords`/`range`/`createClass`/`extendObject`)